### PR TITLE
Simplify README files by removing implementation-specific details

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,7 @@ your-project/
     └── marr/
         ├── MARR-PROJECT-CLAUDE.md  # Project-specific AI agent configuration
         ├── README.md               # Explains the MARR structure
-        └── standards/              # Project-level standards (if installed)
-            ├── prj-git-workflow-standard.md
-            ├── prj-testing-standard.md
-            ├── prj-mcp-usage-standard.md
-            ├── prj-documentation-standard.md
+        └── standards/              # Project-level standards (prj-*.md files)
             └── README.md
 ```
 
@@ -216,10 +212,8 @@ marr clean --all
 ### Standard Prompt Files
 
 **Project-Level** (apply to specific project):
-- `prj-git-workflow-standard.md` - Branch management, commit conventions
-- `prj-testing-standard.md` - Testing philosophy and principles
-- `prj-mcp-usage-standard.md` - MCP tool usage patterns
-- `prj-documentation-standard.md` - Documentation organization
+
+Standards use the `prj-*.md` naming pattern and cover core development concerns: git workflow, testing, MCP usage, documentation, and prompt writing.
 
 Standards live at project level only, keeping projects self-contained and allowing per-project customization.
 

--- a/plans/26-simplify-readme-files.md
+++ b/plans/26-simplify-readme-files.md
@@ -1,0 +1,142 @@
+# Plan: Simplify README Files
+
+> **Issue:** #26 - Simplify README files by removing implementation-specific details
+>
+> **Objective:** Remove hardcoded filenames from README files so documentation remains accurate even when files are renamed, added, or removed.
+>
+> **Expected Outcome:** READMEs describe concepts and patterns (e.g., `prj-*.md`) rather than listing specific filenames, reducing maintenance burden.
+
+---
+
+## Overview
+
+README files currently list specific filenames that become stale when the codebase changes. This plan updates affected READMEs to focus on patterns and concepts rather than implementation details.
+
+**Files requiring changes:**
+1. `resources/project/README.md` - Lists 5 specific standard files
+2. `resources/project/common/README.md` - Lists same 5 files in a table
+3. `resources/user/README.md` - Lists 4 specific standard files
+4. `README.md` (root) - Multiple sections list specific standard files
+
+**Files NOT requiring changes:**
+- `resources/helper-scripts/README.md` - Lists script names that ARE the public interface (users invoke these by name)
+
+---
+
+## STEP01: Update resources/project/README.md
+
+- [ ] Remove explicit file listing from the structure tree, replace with pattern description
+- [ ] Update the table to describe standard categories rather than specific files
+- [ ] Keep the `prj-` naming convention explanation (this is a pattern, not an implementation detail)
+- [ ] Verify the "How They Work" section still makes sense without specific filenames
+- [ ] Validate changes don't break any existing references
+
+**Draft commit message:**
+```
+Simplify resources/project/README.md to use patterns instead of filenames
+
+Replace explicit file listings with pattern-based descriptions (prj-*.md)
+so documentation stays accurate when standards are added or renamed.
+
+Commit for /26-simplify-readme-files/STEP01
+```
+
+---
+
+## STEP02: Update resources/project/common/README.md
+
+- [ ] Remove the file-specific table listing individual standard files
+- [ ] Replace with description of what the directory contains using patterns
+- [ ] Keep the naming convention and customization sections
+- [ ] Verify the README still serves its purpose (explaining the standards directory)
+- [ ] Validate changes are consistent with STEP01 approach
+
+**Draft commit message:**
+```
+Simplify resources/project/common/README.md to use patterns
+
+Replace file-listing table with pattern-based description so docs
+remain accurate as standards evolve.
+
+Commit for /26-simplify-readme-files/STEP02
+```
+
+---
+
+## STEP03: Update resources/user/README.md
+
+- [ ] Remove explicit standard file references under "What Doesn't Go at User Level"
+- [ ] Replace with pattern-based explanation (standards use `prj-` prefix in project's .claude/marr/standards/)
+- [ ] Keep the conceptual explanation of user vs project level
+- [ ] Validate changes are consistent with prior steps
+
+**Draft commit message:**
+```
+Simplify resources/user/README.md to use patterns
+
+Replace explicit file paths with pattern-based descriptions to prevent
+staleness when project-level standards change.
+
+Commit for /26-simplify-readme-files/STEP03
+```
+
+---
+
+## STEP04: Update root README.md
+
+- [ ] Review "What `--project` creates:" section - [ASSUMPTION: keep structure tree but simplify standards listing]
+- [ ] Update "Standard Prompt Files" section to use patterns rather than file list
+- [ ] Review "What it checks" in validate section for hardcoded file references
+- [ ] Keep command examples and usage documentation unchanged (these are user-facing interfaces)
+- [ ] Validate the README still serves its primary purpose (package documentation)
+
+**Draft commit message:**
+```
+Simplify root README.md to reduce hardcoded filenames
+
+Update standard file references to use patterns where appropriate while
+preserving clear usage documentation for the CLI.
+
+Commit for /26-simplify-readme-files/STEP04
+```
+
+---
+
+## STEP05: Final Validation and Documentation
+
+- [ ] Run `marr validate` to ensure no references are broken
+- [ ] Review all changed files for consistency in approach
+- [ ] Verify issue #26 acceptance criteria are met:
+  - [ ] READMEs describe what/why, not specific filenames
+  - [ ] Implementation details live in code, not docs
+  - [ ] Docs remain accurate even after file changes
+- [ ] Update any related documentation if needed
+
+**Draft commit message:**
+```
+Complete issue #26: Validate simplified README files
+
+All READMEs now use pattern-based references instead of hardcoded filenames.
+Documentation will remain accurate as standards evolve.
+
+Closes #26
+
+Commit for /26-simplify-readme-files/STEP05
+```
+
+---
+
+## Approach Notes
+
+**Pattern vs. Filename:**
+- ✅ Use: "Standards follow the `prj-*.md` naming pattern"
+- ❌ Avoid: "prj-git-workflow-standard.md, prj-testing-standard.md, ..."
+
+**Conceptual vs. Implementation:**
+- ✅ Use: "Git workflow, testing, MCP usage, and documentation standards"
+- ❌ Avoid: Listing exact filenames for each
+
+**Keep specific when appropriate:**
+- Helper script names (user invokes these by name)
+- Configuration file paths (CLAUDE.md, MARR-PROJECT-CLAUDE.md are fixed)
+- CLI command syntax (the public interface)

--- a/resources/project/README.md
+++ b/resources/project/README.md
@@ -6,23 +6,18 @@ These standard files define **project-specific standards** that are copied to ea
 
 ```
 project/
-└── common/           # Standard files for all projects
-    ├── prj-git-workflow-standard.md
-    ├── prj-testing-standard.md
-    ├── prj-mcp-usage-standard.md
-    ├── prj-documentation-standard.md
-    └── prj-prompt-writing-standard.md
+└── common/           # Standard files (prj-*.md) for all projects
 ```
 
-## Files
+## Standard Categories
 
-| File | Purpose |
-|------|---------|
-| `prj-git-workflow-standard.md` | Project-specific git rules |
-| `prj-testing-standard.md` | Project-specific testing approach |
-| `prj-mcp-usage-standard.md` | Project-specific MCP usage |
-| `prj-documentation-standard.md` | Project documentation organization |
-| `prj-prompt-writing-standard.md` | How to write effective prompts |
+Standards cover core development concerns:
+
+- **Git workflow** - Branching, commits, PRs
+- **Testing** - Testing philosophy and approach
+- **MCP usage** - Model Context Protocol tool patterns
+- **Documentation** - Project documentation organization
+- **Prompt writing** - How to write effective AI prompts
 
 ## Naming Convention
 

--- a/resources/project/common/README.md
+++ b/resources/project/common/README.md
@@ -2,15 +2,15 @@
 
 This directory contains **project-specific standards** that Claude Code follows when working in this repository.
 
-## Files
+## Contents
 
-| File | Purpose |
-|------|---------|
-| `prj-git-workflow-standard.md` | Git branching, commits, PRs for this project |
-| `prj-testing-standard.md` | Testing approach for this project |
-| `prj-mcp-usage-standard.md` | MCP tool usage for this project |
-| `prj-documentation-standard.md` | Documentation organization for this project |
-| `prj-prompt-writing-standard.md` | How to write and modify prompts |
+All files follow the `prj-*.md` naming pattern and cover core development concerns:
+
+- Git workflow (branching, commits, PRs)
+- Testing philosophy and approach
+- MCP tool usage patterns
+- Documentation organization
+- Prompt writing guidelines
 
 ## How It Works
 

--- a/resources/user/README.md
+++ b/resources/user/README.md
@@ -13,12 +13,7 @@ User-level configuration (`~/.claude/marr/`) contains **personal preferences** t
 
 ## What Doesn't Go at User Level
 
-**Standards and prompts belong at project level**, not user level:
-
-- Git workflow standards → `./.claude/marr/prj-git-workflow-standard.md`
-- Testing standards → `./.claude/marr/prj-testing-standard.md`
-- MCP usage standards → `./.claude/marr/prj-mcp-usage-standard.md`
-- Documentation standards → `./.claude/marr/prj-documentation-standard.md`
+**Standards belong at project level**, not user level. All `prj-*.md` files live in the project's `.claude/marr/standards/` directory, covering git workflow, testing, MCP usage, documentation, and prompts.
 
 This keeps projects self-contained and allows per-project customization.
 


### PR DESCRIPTION
## Summary

- Replace hardcoded filenames with pattern-based references (`prj-*.md`) in README files
- Fix incorrect path in `resources/user/README.md` (was missing `standards/` subdirectory)
- Documentation now remains accurate when standards are added, renamed, or removed

## Files Changed

| File | Change |
|------|--------|
| `README.md` | Simplified structure tree and standard files section |
| `resources/project/README.md` | Replaced 5-file listing with pattern and categories |
| `resources/project/common/README.md` | Replaced file table with pattern-based content |
| `resources/user/README.md` | Replaced explicit paths with single pattern reference |

## Test plan

- [x] `marr validate` passes
- [x] All acceptance criteria from issue #26 verified

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)