### PR TITLE
Fix README.md to reflect actual standards structure

### DIFF
--- a/.claude/marr/README.md
+++ b/.claude/marr/README.md
@@ -19,11 +19,11 @@ MARR uses a two-layer configuration system:
 ├── MARR-PROJECT-CLAUDE.md   # Project configuration (imported by CLAUDE.md)
 ├── README.md                # This file
 └── standards/               # Project-level standards
-    ├── prj-git-workflow-standard.md
-    ├── prj-testing-standard.md
-    ├── prj-mcp-usage-standard.md
     ├── prj-documentation-standard.md
-    ├── prj-what-is-a-standard.md
+    ├── prj-mcp-usage-standard.md
+    ├── prj-testing-standard.md
+    ├── prj-ui-ux-standard.md
+    ├── prj-workflow-standard.md
     └── prj-writing-prompts-standard.md
 ```
 


### PR DESCRIPTION
## Summary

- Update `.claude/marr/README.md` file listing to match actual standards
- Remove reference to non-existent `prj-what-is-a-standard.md` (content is in MARR-PROJECT-CLAUDE.md)
- Fix `prj-git-workflow-standard.md` → `prj-workflow-standard.md`
- Add missing `prj-ui-ux-standard.md`

## Context

The "What is a Standard" content was incorporated directly into `MARR-PROJECT-CLAUDE.md` as foundational context that agents need before any triggers fire. The README had drifted out of sync with the actual file structure.

Closes #43