### PR TITLE
Add marr sync command to propagate standards between projects

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -14,6 +14,7 @@ import matter from 'gray-matter';
 import * as logger from '../utils/logger.js';
 import * as fileOps from '../utils/file-ops.js';
 import * as marrSetup from '../utils/marr-setup.js';
+import { registerProject } from '../utils/project-registry.js';
 
 interface InitOptions {
   user: boolean;
@@ -489,6 +490,9 @@ async function initializeProject(targetDir: string, standards: string | undefine
 
   // Handle project root CLAUDE.md
   addProjectClaudeMdImport(projectClaudeMdPath, targetDir);
+
+  // Register project in sync registry
+  registerProject(targetDir);
 
   logger.blank();
   logger.success('Project configuration created!');

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,0 +1,533 @@
+/**
+ * Sync command - Propagate standards between MARR-configured projects
+ *
+ * Usage:
+ *   marr sync                    Interactive mode - prompts for source/targets
+ *   marr sync --from <path>      Specify source project
+ *   marr sync --to <path>        Specify target project (can repeat)
+ *   marr sync --only <file>      Sync specific standard(s) only
+ *   marr sync --dry-run          Preview changes without applying
+ *   marr sync --force            Skip confirmation prompts
+ *   marr sync --register         Add current project to registry
+ *   marr sync --unregister       Remove current project from registry
+ *   marr sync --list             Show registered projects
+ */
+
+import { Command } from 'commander';
+import { join, basename } from 'path';
+import * as readline from 'readline';
+import * as logger from '../utils/logger.js';
+import * as fileOps from '../utils/file-ops.js';
+import {
+  registerProject,
+  unregisterProject,
+  listProjects,
+  listValidProjects,
+  isMarrProject,
+  cleanRegistry,
+} from '../utils/project-registry.js';
+import { regenerateTriggerTable } from '../utils/trigger-regenerator.js';
+
+interface SyncOptions {
+  from?: string;
+  to?: string[];
+  only?: string;
+  dryRun?: boolean;
+  force?: boolean;
+  register?: boolean;
+  unregister?: boolean;
+  list?: boolean;
+}
+
+const STANDARDS_DIR = join('.claude', 'marr', 'standards');
+
+/**
+ * Create readline interface for interactive prompts
+ */
+function createReadline(): readline.Interface {
+  return readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+}
+
+/**
+ * Prompt user for input
+ */
+function prompt(rl: readline.Interface, question: string): Promise<string> {
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      resolve(answer.trim());
+    });
+  });
+}
+
+/**
+ * Select from a numbered list interactively
+ */
+async function selectFromList(
+  rl: readline.Interface,
+  items: string[],
+  promptText: string,
+  allowMultiple = false
+): Promise<string[]> {
+  logger.blank();
+  logger.info(promptText);
+  logger.blank();
+
+  items.forEach((item, index) => {
+    logger.log(`  ${index + 1}) ${item}`);
+  });
+
+  logger.blank();
+
+  if (allowMultiple) {
+    const answer = await prompt(rl, 'Enter numbers (comma-separated) or "all": ');
+
+    if (answer.toLowerCase() === 'all') {
+      return items;
+    }
+
+    const indices = answer
+      .split(',')
+      .map((s) => parseInt(s.trim(), 10) - 1)
+      .filter((i) => i >= 0 && i < items.length);
+
+    return indices.map((i) => items[i]);
+  } else {
+    const answer = await prompt(rl, 'Enter number: ');
+    const index = parseInt(answer, 10) - 1;
+
+    if (index >= 0 && index < items.length) {
+      return [items[index]];
+    }
+
+    return [];
+  }
+}
+
+/**
+ * Get list of standard files in a project
+ */
+function getStandardFiles(projectPath: string): string[] {
+  const standardsPath = join(projectPath, STANDARDS_DIR);
+
+  if (!fileOps.exists(standardsPath)) {
+    return [];
+  }
+
+  const files = fileOps.listFiles(standardsPath, false);
+  return files
+    .filter((f) => f.endsWith('.md') && basename(f) !== 'README.md')
+    .map((f) => basename(f));
+}
+
+/**
+ * Compare two files and return whether they differ
+ */
+function filesAreDifferent(path1: string, path2: string): boolean {
+  if (!fileOps.exists(path1) || !fileOps.exists(path2)) {
+    return true;
+  }
+
+  try {
+    const content1 = fileOps.readFile(path1);
+    const content2 = fileOps.readFile(path2);
+    return content1 !== content2;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Generate a simple unified diff between two strings
+ */
+function generateDiff(oldContent: string, newContent: string, filename: string): string {
+  const oldLines = oldContent.split('\n');
+  const newLines = newContent.split('\n');
+
+  const lines: string[] = [];
+  lines.push(`--- a/${filename}`);
+  lines.push(`+++ b/${filename}`);
+
+  // Simple line-by-line diff (not a true unified diff algorithm, but sufficient)
+  const maxLines = Math.max(oldLines.length, newLines.length);
+  let inHunk = false;
+  let hunkStart = -1;
+
+  for (let i = 0; i < maxLines; i++) {
+    const oldLine = oldLines[i];
+    const newLine = newLines[i];
+
+    if (oldLine !== newLine) {
+      if (!inHunk) {
+        hunkStart = i;
+        inHunk = true;
+        lines.push(`@@ -${i + 1} +${i + 1} @@`);
+      }
+
+      if (oldLine !== undefined) {
+        lines.push(`-${oldLine}`);
+      }
+      if (newLine !== undefined) {
+        lines.push(`+${newLine}`);
+      }
+    } else if (inHunk) {
+      // Context line after changes
+      lines.push(` ${oldLine || ''}`);
+      if (i - hunkStart > 3) {
+        inHunk = false;
+      }
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Sync standards from source to target project
+ */
+async function syncProjects(
+  sourcePath: string,
+  targetPath: string,
+  options: { only?: string; dryRun?: boolean; force?: boolean },
+  rl: readline.Interface
+): Promise<{ synced: number; skipped: number }> {
+  const sourceStandardsDir = join(sourcePath, STANDARDS_DIR);
+  const targetStandardsDir = join(targetPath, STANDARDS_DIR);
+
+  if (!fileOps.exists(sourceStandardsDir)) {
+    logger.warning(`No standards directory in source: ${sourcePath}`);
+    return { synced: 0, skipped: 0 };
+  }
+
+  // Get source standards
+  let sourceFiles = getStandardFiles(sourcePath);
+
+  // Filter by --only if specified
+  if (options.only) {
+    const onlyFiles = options.only.split(',').map((f) => f.trim());
+    sourceFiles = sourceFiles.filter((f) => onlyFiles.includes(f));
+  }
+
+  if (sourceFiles.length === 0) {
+    logger.info('No standards to sync');
+    return { synced: 0, skipped: 0 };
+  }
+
+  let synced = 0;
+  let skipped = 0;
+
+  for (const file of sourceFiles) {
+    const sourcePath_ = join(sourceStandardsDir, file);
+    const targetPath_ = join(targetStandardsDir, file);
+
+    const sourceExists = fileOps.exists(sourcePath_);
+    const targetExists = fileOps.exists(targetPath_);
+
+    if (!sourceExists) {
+      continue;
+    }
+
+    const isDifferent = !targetExists || filesAreDifferent(sourcePath_, targetPath_);
+
+    if (!isDifferent) {
+      continue; // Already in sync
+    }
+
+    const sourceContent = fileOps.readFile(sourcePath_);
+    const targetContent = targetExists ? fileOps.readFile(targetPath_) : '';
+
+    // Show diff
+    logger.blank();
+    if (targetExists) {
+      logger.info(`Changes for ${file}:`);
+      const diff = generateDiff(targetContent, sourceContent, file);
+      logger.log(diff);
+    } else {
+      logger.info(`New file: ${file}`);
+    }
+
+    // Prompt for confirmation unless --force or --dry-run
+    let shouldSync = options.force || false;
+
+    if (!options.dryRun && !options.force) {
+      const answer = await prompt(rl, `\nApply changes to ${file}? [y/N] `);
+      shouldSync = answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes';
+    }
+
+    if (options.dryRun) {
+      logger.info(`[dry-run] Would sync: ${file}`);
+      synced++;
+    } else if (shouldSync) {
+      fileOps.ensureDir(targetStandardsDir);
+      fileOps.copyFile(sourcePath_, targetPath_);
+      logger.success(`Synced: ${file}`);
+      synced++;
+    } else {
+      logger.info(`Skipped: ${file}`);
+      skipped++;
+    }
+  }
+
+  // Regenerate trigger table if any files were synced
+  if (synced > 0 && !options.dryRun) {
+    const result = regenerateTriggerTable(targetPath);
+    if (result.success) {
+      logger.success(`Regenerated trigger table (${result.standardsCount} standards)`);
+    } else if (result.error) {
+      logger.warning(`Could not regenerate trigger table: ${result.error}`);
+    }
+  }
+
+  return { synced, skipped };
+}
+
+/**
+ * Handle --register flag
+ */
+function handleRegister(): void {
+  const cwd = process.cwd();
+
+  if (!isMarrProject(cwd)) {
+    logger.error('Current directory is not a MARR-configured project');
+    logger.info('Run: marr init --project');
+    process.exit(1);
+  }
+
+  const added = registerProject(cwd);
+
+  if (added) {
+    logger.success(`Registered: ${cwd}`);
+  } else {
+    logger.info(`Already registered: ${cwd}`);
+  }
+}
+
+/**
+ * Handle --unregister flag
+ */
+function handleUnregister(): void {
+  const cwd = process.cwd();
+  const removed = unregisterProject(cwd);
+
+  if (removed) {
+    logger.success(`Unregistered: ${cwd}`);
+  } else {
+    logger.info(`Not registered: ${cwd}`);
+  }
+}
+
+/**
+ * Handle --list flag
+ */
+function handleList(): void {
+  const projects = listProjects();
+
+  logger.section('Registered Projects');
+  logger.blank();
+
+  if (projects.length === 0) {
+    logger.info('No projects registered');
+    logger.blank();
+    logger.info('Register projects with: marr sync --register');
+    logger.info('Or run: marr init --project (auto-registers)');
+  } else {
+    // Clean up invalid projects first
+    const removed = cleanRegistry();
+    if (removed.length > 0) {
+      logger.warning(`Removed ${removed.length} invalid project(s) from registry`);
+      logger.blank();
+    }
+
+    const validProjects = listValidProjects();
+
+    for (const project of projects) {
+      const isValid = validProjects.includes(project);
+      if (isValid) {
+        logger.log(`  ${project}`);
+      } else {
+        logger.log(`  ${project} (not found)`);
+      }
+    }
+
+    logger.blank();
+    logger.info(`${validProjects.length} project(s) registered`);
+  }
+
+  logger.blank();
+}
+
+/**
+ * Main sync execution
+ */
+async function executeSync(options: SyncOptions): Promise<void> {
+  // Handle registry management flags
+  if (options.register) {
+    handleRegister();
+    return;
+  }
+
+  if (options.unregister) {
+    handleUnregister();
+    return;
+  }
+
+  if (options.list) {
+    handleList();
+    return;
+  }
+
+  // Get valid projects for sync
+  const validProjects = listValidProjects();
+
+  if (validProjects.length === 0) {
+    logger.error('No MARR projects registered');
+    logger.blank();
+    logger.info('Register projects first:');
+    logger.log('  cd /path/to/project && marr sync --register');
+    logger.log('  Or: marr init --project (auto-registers)');
+    process.exit(1);
+  }
+
+  const rl = createReadline();
+
+  try {
+    // Determine source
+    let sourcePath: string;
+
+    if (options.from) {
+      sourcePath = options.from.startsWith('/') ? options.from : join(process.cwd(), options.from);
+
+      if (!isMarrProject(sourcePath)) {
+        logger.error(`Not a MARR project: ${sourcePath}`);
+        process.exit(1);
+      }
+    } else {
+      // Interactive source selection
+      const selected = await selectFromList(
+        rl,
+        validProjects,
+        'Select SOURCE project (sync FROM):',
+        false
+      );
+
+      if (selected.length === 0) {
+        logger.info('No source selected. Cancelled.');
+        rl.close();
+        return;
+      }
+
+      sourcePath = selected[0];
+    }
+
+    // Determine targets
+    let targetPaths: string[];
+
+    if (options.to && options.to.length > 0) {
+      targetPaths = options.to.map((p) => (p.startsWith('/') ? p : join(process.cwd(), p)));
+
+      // Validate targets
+      for (const target of targetPaths) {
+        if (!isMarrProject(target)) {
+          logger.error(`Not a MARR project: ${target}`);
+          process.exit(1);
+        }
+      }
+    } else {
+      // Interactive target selection (exclude source)
+      const availableTargets = validProjects.filter((p) => p !== sourcePath);
+
+      if (availableTargets.length === 0) {
+        logger.error('No other projects to sync to');
+        logger.info('Register more projects with: marr sync --register');
+        rl.close();
+        process.exit(1);
+      }
+
+      targetPaths = await selectFromList(
+        rl,
+        availableTargets,
+        'Select TARGET project(s) (sync TO):',
+        true
+      );
+
+      if (targetPaths.length === 0) {
+        logger.info('No targets selected. Cancelled.');
+        rl.close();
+        return;
+      }
+    }
+
+    // Perform sync
+    logger.section(options.dryRun ? 'Sync Preview (Dry Run)' : 'Syncing Standards');
+    logger.blank();
+    logger.info(`Source: ${sourcePath}`);
+    logger.info(`Targets: ${targetPaths.length} project(s)`);
+
+    let totalSynced = 0;
+    let totalSkipped = 0;
+
+    for (const targetPath of targetPaths) {
+      logger.blank();
+      logger.info(`→ ${targetPath}`);
+
+      const result = await syncProjects(sourcePath, targetPath, options, rl);
+      totalSynced += result.synced;
+      totalSkipped += result.skipped;
+    }
+
+    // Summary
+    logger.blank();
+    if (options.dryRun) {
+      logger.info(`Dry run complete: ${totalSynced} file(s) would be synced`);
+    } else {
+      logger.success(`Sync complete: ${totalSynced} file(s) synced, ${totalSkipped} skipped`);
+    }
+
+    rl.close();
+  } catch (err) {
+    rl.close();
+    throw err;
+  }
+}
+
+/**
+ * Register the sync command
+ */
+export function syncCommand(program: Command): void {
+  program
+    .command('sync')
+    .description('Sync standards between MARR-configured projects')
+    .option('--from <path>', 'Source project path')
+    .option('--to <path...>', 'Target project path(s)')
+    .option('--only <files>', 'Sync specific standard(s) only (comma-separated)')
+    .option('-n, --dry-run', 'Preview changes without applying')
+    .option('-f, --force', 'Skip confirmation prompts')
+    .option('--register', 'Add current project to registry')
+    .option('--unregister', 'Remove current project from registry')
+    .option('--list', 'Show registered projects')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ marr sync                    Interactive mode - select source and targets
+  $ marr sync --from ~/proj/a --to ~/proj/b   Sync from A to B
+  $ marr sync --only prj-workflow-standard.md   Sync specific standard
+  $ marr sync --dry-run          Preview changes
+  $ marr sync --force            Skip confirmations
+  $ marr sync --register         Add current project to registry
+  $ marr sync --unregister       Remove current project from registry
+  $ marr sync --list             Show registered projects
+
+Projects are auto-registered when you run 'marr init --project'.`
+    )
+    .action(async (options: SyncOptions) => {
+      try {
+        await executeSync(options);
+      } catch (err) {
+        logger.error((err as Error).message);
+        process.exit(1);
+      }
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { validateCommand } from './commands/validate.js';
 import { cleanCommand } from './commands/clean.js';
 import { standardCommand } from './commands/standard.js';
 import { doctorCommand } from './commands/doctor.js';
+import { syncCommand } from './commands/sync.js';
 
 // Get package.json for version
 const __filename = fileURLToPath(import.meta.url);
@@ -43,6 +44,7 @@ Examples:
   $ marr clean --project          Remove project MARR config
   $ marr standard validate --all  Validate all standard frontmatter
   $ marr standard list            List standards with triggers
+  $ marr sync                     Sync standards between projects
 
 Run 'marr <command> --help' for detailed help on each command.`);
 
@@ -52,6 +54,7 @@ validateCommand(program);
 cleanCommand(program);
 standardCommand(program);
 doctorCommand(program);
+syncCommand(program);
 
 // Parse arguments
 program.parse(process.argv);

--- a/src/utils/project-registry.ts
+++ b/src/utils/project-registry.ts
@@ -1,0 +1,134 @@
+/**
+ * Project Registry - Track MARR-configured projects for sync
+ *
+ * Stores a list of project paths in ~/.claude/marr/projects.json
+ * Used by `marr sync` to discover source and target projects.
+ */
+
+import { join } from 'path';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import * as fileOps from './file-ops.js';
+
+interface ProjectRegistry {
+  projects: string[];
+}
+
+const REGISTRY_FILE = 'projects.json';
+
+/**
+ * Get path to the registry file
+ */
+export function getRegistryPath(): string {
+  return join(fileOps.getMarrRoot(), REGISTRY_FILE);
+}
+
+/**
+ * Load the project registry, creating empty one if it doesn't exist
+ */
+export function loadRegistry(): ProjectRegistry {
+  const registryPath = getRegistryPath();
+
+  if (!existsSync(registryPath)) {
+    return { projects: [] };
+  }
+
+  try {
+    const content = readFileSync(registryPath, 'utf8');
+    const data = JSON.parse(content) as ProjectRegistry;
+
+    // Validate structure
+    if (!Array.isArray(data.projects)) {
+      return { projects: [] };
+    }
+
+    return data;
+  } catch {
+    return { projects: [] };
+  }
+}
+
+/**
+ * Save the project registry
+ */
+export function saveRegistry(registry: ProjectRegistry): void {
+  const registryPath = getRegistryPath();
+  fileOps.ensureDir(fileOps.getMarrRoot());
+  writeFileSync(registryPath, JSON.stringify(registry, null, 2) + '\n', 'utf8');
+}
+
+/**
+ * Check if a path is a MARR-configured project
+ */
+export function isMarrProject(projectPath: string): boolean {
+  const marrConfigPath = join(projectPath, '.claude', 'marr', 'MARR-PROJECT-CLAUDE.md');
+  return existsSync(marrConfigPath);
+}
+
+/**
+ * Register a project in the registry
+ * Returns true if newly added, false if already registered
+ */
+export function registerProject(projectPath: string): boolean {
+  const registry = loadRegistry();
+  const normalizedPath = projectPath.replace(/\/$/, ''); // Remove trailing slash
+
+  if (registry.projects.includes(normalizedPath)) {
+    return false;
+  }
+
+  registry.projects.push(normalizedPath);
+  registry.projects.sort(); // Keep sorted for consistent ordering
+  saveRegistry(registry);
+  return true;
+}
+
+/**
+ * Unregister a project from the registry
+ * Returns true if removed, false if wasn't registered
+ */
+export function unregisterProject(projectPath: string): boolean {
+  const registry = loadRegistry();
+  const normalizedPath = projectPath.replace(/\/$/, '');
+
+  const index = registry.projects.indexOf(normalizedPath);
+  if (index === -1) {
+    return false;
+  }
+
+  registry.projects.splice(index, 1);
+  saveRegistry(registry);
+  return true;
+}
+
+/**
+ * List all registered projects
+ */
+export function listProjects(): string[] {
+  const registry = loadRegistry();
+  return registry.projects;
+}
+
+/**
+ * List registered projects that still exist and have MARR config
+ * Useful for filtering out deleted/moved projects
+ */
+export function listValidProjects(): string[] {
+  const registry = loadRegistry();
+  return registry.projects.filter(isMarrProject);
+}
+
+/**
+ * Clean up registry by removing projects that no longer exist or have MARR config
+ * Returns list of removed paths
+ */
+export function cleanRegistry(): string[] {
+  const registry = loadRegistry();
+  const validProjects = registry.projects.filter(isMarrProject);
+  const removed = registry.projects.filter((p) => !validProjects.includes(p));
+
+  if (removed.length > 0) {
+    saveRegistry({ projects: validProjects });
+  }
+
+  return removed;
+}

--- a/src/utils/trigger-regenerator.ts
+++ b/src/utils/trigger-regenerator.ts
@@ -1,0 +1,268 @@
+/**
+ * Trigger Table Regenerator
+ *
+ * Regenerates the Standards section in MARR-PROJECT-CLAUDE.md
+ * from the frontmatter in standard files.
+ *
+ * Used by `marr sync` after copying standards to target projects.
+ */
+
+import { join, basename } from 'path';
+import { statSync } from 'fs';
+import matter from 'gray-matter';
+import * as fileOps from './file-ops.js';
+import { StandardFrontmatterSchema, StandardFrontmatter, formatTrigger } from '../schema/standard.js';
+
+const STANDARDS_DIR = join('.claude', 'marr', 'standards');
+const CONFIG_FILE = join('.claude', 'marr', 'MARR-PROJECT-CLAUDE.md');
+const STANDARDS_SECTION_START = '## Standards';
+const STANDARDS_SECTION_END = '---';
+
+interface ParsedStandard {
+  path: string;
+  filename: string;
+  frontmatter: StandardFrontmatter;
+  content: string;
+}
+
+interface ValidationError {
+  path: string;
+  errors: string[];
+}
+
+/**
+ * Verify file is owned by current user (security check)
+ */
+function isOwnedByCurrentUser(filePath: string): boolean {
+  try {
+    const stat = statSync(filePath);
+    const currentUid = process.getuid?.();
+    if (currentUid === undefined) {
+      return true;
+    }
+    return stat.uid === currentUid;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Parse a standard file and validate its frontmatter
+ */
+function parseStandardFile(filePath: string): ParsedStandard | ValidationError {
+  const content = fileOps.readFile(filePath);
+  const filename = basename(filePath);
+
+  let parsed;
+  try {
+    parsed = matter(content);
+  } catch (err) {
+    return {
+      path: filePath,
+      errors: [`Failed to parse YAML frontmatter: ${err instanceof Error ? err.message : String(err)}`],
+    };
+  }
+
+  if (parsed.data.marr !== 'standard') {
+    return {
+      path: filePath,
+      errors: ['Missing or invalid "marr: standard" discriminator'],
+    };
+  }
+
+  const result = StandardFrontmatterSchema.safeParse(parsed.data);
+
+  if (!result.success) {
+    const errors = result.error.issues.map((issue) => {
+      const path = issue.path.join('.');
+      return path ? `${path}: ${issue.message}` : issue.message;
+    });
+    return { path: filePath, errors };
+  }
+
+  return {
+    path: filePath,
+    filename,
+    frontmatter: result.data,
+    content: parsed.content,
+  };
+}
+
+function isValidationError(result: ParsedStandard | ValidationError): result is ValidationError {
+  return 'errors' in result;
+}
+
+/**
+ * Find all standard files in a directory
+ */
+function findStandardFiles(dir: string): string[] {
+  if (!fileOps.exists(dir)) {
+    return [];
+  }
+
+  const files = fileOps.listFiles(dir, false);
+  return files.filter((f) => f.endsWith('.md') && basename(f) !== 'README.md');
+}
+
+/**
+ * Generate standard entry with triggers as bullet list
+ */
+function generateStandardEntry(standard: ParsedStandard): string {
+  const triggers = standard.frontmatter.triggers.map(formatTrigger);
+  const bulletList = triggers.map((t) => `- ${t}`).join('\n');
+
+  return `### \`${standard.filename}\`
+Read this standard when:
+${bulletList}`;
+}
+
+export interface RegenerateResult {
+  success: boolean;
+  standardsCount: number;
+  skipped: { path: string; reason: string }[];
+  error?: string;
+}
+
+/**
+ * Regenerate the trigger table in a project's MARR-PROJECT-CLAUDE.md
+ *
+ * @param projectPath - Path to the project root
+ * @returns Result object with success status and details
+ */
+export function regenerateTriggerTable(projectPath: string): RegenerateResult {
+  const standardsDir = join(projectPath, STANDARDS_DIR);
+  const configPath = join(projectPath, CONFIG_FILE);
+
+  // Check standards directory exists
+  if (!fileOps.exists(standardsDir)) {
+    return {
+      success: false,
+      standardsCount: 0,
+      skipped: [],
+      error: `Standards directory not found: ${STANDARDS_DIR}/`,
+    };
+  }
+
+  // Check config file exists
+  if (!fileOps.exists(configPath)) {
+    return {
+      success: false,
+      standardsCount: 0,
+      skipped: [],
+      error: `Config file not found: ${CONFIG_FILE}`,
+    };
+  }
+
+  const files = findStandardFiles(standardsDir);
+
+  if (files.length === 0) {
+    return {
+      success: true,
+      standardsCount: 0,
+      skipped: [],
+    };
+  }
+
+  // Parse and verify ownership of each standard
+  const validStandards: ParsedStandard[] = [];
+  const skipped: { path: string; reason: string }[] = [];
+
+  for (const file of files) {
+    if (!isOwnedByCurrentUser(file)) {
+      skipped.push({ path: file, reason: 'not owned by current user' });
+      continue;
+    }
+
+    const result = parseStandardFile(file);
+
+    if (isValidationError(result)) {
+      skipped.push({ path: file, reason: 'invalid frontmatter' });
+      continue;
+    }
+
+    validStandards.push(result);
+  }
+
+  if (validStandards.length === 0) {
+    return {
+      success: false,
+      standardsCount: 0,
+      skipped,
+      error: 'No valid standards to process',
+    };
+  }
+
+  // Sort standards alphabetically for consistent output
+  validStandards.sort((a, b) => a.filename.localeCompare(b.filename));
+
+  // Generate standard entries
+  const entries = validStandards.map(generateStandardEntry);
+  const newSection = `${STANDARDS_SECTION_START}
+
+\`standards/\` contains standard prompt files that must be followed when working on a related activity.
+
+**IMPORTANT: Conditional Reading Protocol**
+
+1. **DO NOT read standards proactively** — Only read a standard when its trigger condition matches your current task
+2. **Evaluate triggers against your current task** — Before each task, scan the trigger list below and identify which (if any) apply
+3. **Read triggered standards before proceeding** — When a trigger matches, read the full standard file immediately
+4. **Multiple triggers = multiple reads** — If more than one trigger matches, read all corresponding standards
+
+${entries.join('\n\n')}
+
+${STANDARDS_SECTION_END}`;
+
+  // Read config file
+  const configContent = fileOps.readFile(configPath);
+
+  // Find and replace existing standards section
+  const lines = configContent.split('\n');
+  let sectionStartIndex = -1;
+  let sectionEndIndex = -1;
+
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() === STANDARDS_SECTION_START) {
+      sectionStartIndex = i;
+    } else if (sectionStartIndex !== -1 && sectionEndIndex === -1) {
+      if (lines[i].trim() === STANDARDS_SECTION_END) {
+        sectionEndIndex = i + 1;
+        break;
+      }
+    }
+  }
+
+  if (sectionStartIndex === -1) {
+    return {
+      success: false,
+      standardsCount: validStandards.length,
+      skipped,
+      error: 'Could not find Standards section in config file',
+    };
+  }
+
+  if (sectionEndIndex === -1) {
+    return {
+      success: false,
+      standardsCount: validStandards.length,
+      skipped,
+      error: 'Could not find end of Standards section (---)',
+    };
+  }
+
+  // Build new content
+  const newLines = [
+    ...lines.slice(0, sectionStartIndex),
+    ...newSection.split('\n'),
+    ...lines.slice(sectionEndIndex),
+  ];
+  const newContent = newLines.join('\n');
+
+  // Write updated config
+  fileOps.writeFile(configPath, newContent);
+
+  return {
+    success: true,
+    standardsCount: validStandards.length,
+    skipped,
+  };
+}


### PR DESCRIPTION
## Summary

- Add `marr sync` command for propagating standards between MARR-configured projects
- Add project registry at `~/.claude/marr/projects.json`
- Auto-register projects on `marr init --project`
- Auto-regenerate trigger tables after syncing
- Remove `marr standard sync` (functionality folded into `marr sync`)

## Usage

```bash
# Interactive mode - prompts for source and targets
marr sync

# Explicit source and target
marr sync --from ~/projects/marr --to ~/projects/npm-scanner

# Preview changes
marr sync --dry-run

# Manage registry
marr sync --register      # Add current project
marr sync --unregister    # Remove current project
marr sync --list          # Show registered projects
```

Closes #37

## Test plan

- [x] Build passes
- [x] All 49 tests pass
- [x] `marr sync --help` shows correct usage
- [x] `marr sync --register` adds project to registry
- [x] `marr sync --list` shows registered projects
- [ ] Manual testing of sync between projects