### PR TITLE
Add docs link to MARR-PROJECT-CLAUDE.md

### DIFF
--- a/resources/project/MARR-PROJECT-CLAUDE.md
+++ b/resources/project/MARR-PROJECT-CLAUDE.md
@@ -10,7 +10,7 @@
 
 MARR (Making Agents Really Reliable) provides project-level AI agent configuration.
 
-See `.claude/marr/README.md` for how MARR works.
+See `.claude/marr/README.md` for how MARR works, or visit [virtualian.github.io/marr](https://virtualian.github.io/marr).
 
 ## What is a Standard
 


### PR DESCRIPTION
Adds link to virtualian.github.io/marr in the project CLAUDE template.

Closes #75