### PR TITLE
Add STOP-GATE pattern for branch verification

### DIFF
--- a/resources/project/common/prj-development-workflow-standard.md
+++ b/resources/project/common/prj-development-workflow-standard.md
@@ -6,6 +6,9 @@ scope: All development work involving issues, tasks, and release processes
 
 triggers:
   - WHEN starting any task or implementation work
+  - WHEN asked to investigate, look at, check, debug, or troubleshoot something
+  - WHEN a user references an issue number or asks to work on a specific issue
+  - WHEN implementing, building, adding, changing, or modifying functionality
   - WHEN creating or managing issues
   - WHEN preparing a release
   - WHEN responding to a production incident
@@ -23,6 +26,29 @@ triggers:
 2. **NEVER start implementation without an issue number** because all work must be traceable
 3. **Create branch BEFORE investigation** because even exploration should be tracked
 4. **Update documentation when code changes** because outdated docs mislead users
+
+---
+
+## STOP-GATE: Branch Verification (MANDATORY)
+
+**THIS SECTION IS A HARD GATE. COMPLETE THESE STEPS BEFORE ANY OTHER ACTION.**
+
+When this standard is triggered, IMMEDIATELY verify branch status:
+
+1. **Check current branch** — Determine which branch you are on
+2. **If on main**: STOP. Create a feature branch BEFORE proceeding with any other action
+3. **If on a feature branch**: Verify the branch name corresponds to the issue being worked on
+
+**When on main and asked to investigate, fix, or work on something:**
+- DO NOT read code files
+- DO NOT run searches
+- DO NOT explore the codebase
+- DO NOT make any changes
+- FIRST create the appropriate feature branch, THEN proceed
+
+**Rationale:** Even "just looking" or "quick investigation" creates context that leads to changes. Branch first ensures all work—including exploration—is properly tracked and isolated.
+
+**No exceptions. No "quick looks". Branch first, always.**
 
 ---
 
@@ -102,6 +128,7 @@ Hotfixes are emergency fixes for production issues.
 ## Anti-Patterns (FORBIDDEN)
 
 - **Working without an issue** — All work must be tracked
+- **Investigating on main** — Even "just looking" must happen on a feature branch
 - **Starting code before branching** — Branch first, then investigate
 - **Bypassing process for "quick fixes"** — Process applies to all changes
 - **Combining unrelated work** — One issue per branch (unless explicitly instructed)


### PR DESCRIPTION
## Summary

- Adds expanded triggers to catch natural user phrases like "work on issue X", "investigate", "look at", etc.
- Introduces a STOP-GATE section as a mandatory first-action gate requiring branch verification before any other action
- Adds "Investigating on main" as an explicit anti-pattern

Closes #93

## Test plan

- [x] Standard validates with `marr standard validate`
- [x] All 49 tests pass
- [ ] Manual testing: ask an agent to "work on issue X" and verify it checks/creates branch before exploring