### PR TITLE
Mandate release notes and GitHub Release

### DIFF
--- a/.claude/marr/standards/prj-development-workflow-standard.md
+++ b/.claude/marr/standards/prj-development-workflow-standard.md
@@ -6,6 +6,9 @@ scope: All development work involving issues, tasks, and release processes
 
 triggers:
   - WHEN starting any task or implementation work
+  - WHEN asked to investigate, look at, check, debug, or troubleshoot something
+  - WHEN a user references an issue number or asks to work on a specific issue
+  - WHEN implementing, building, adding, changing, or modifying functionality
   - WHEN creating or managing issues
   - WHEN preparing a release
   - WHEN responding to a production incident
@@ -23,6 +26,29 @@ triggers:
 2. **NEVER start implementation without an issue number** because all work must be traceable
 3. **Create branch BEFORE investigation** because even exploration should be tracked
 4. **Update documentation when code changes** because outdated docs mislead users
+
+---
+
+## STOP-GATE: Branch Verification (MANDATORY)
+
+**THIS SECTION IS A HARD GATE. COMPLETE THESE STEPS BEFORE ANY OTHER ACTION.**
+
+When this standard is triggered, IMMEDIATELY verify branch status:
+
+1. **Check current branch** — Determine which branch you are on
+2. **If on main**: STOP. Create a feature branch BEFORE proceeding with any other action
+3. **If on a feature branch**: Verify the branch name corresponds to the issue being worked on
+
+**When on main and asked to investigate, fix, or work on something:**
+- DO NOT read code files
+- DO NOT run searches
+- DO NOT explore the codebase
+- DO NOT make any changes
+- FIRST create the appropriate feature branch, THEN proceed
+
+**Rationale:** Even "just looking" or "quick investigation" creates context that leads to changes. Branch first ensures all work—including exploration—is properly tracked and isolated.
+
+**No exceptions. No "quick looks". Branch first, always.**
 
 ---
 
@@ -74,10 +100,14 @@ Before starting any work:
 **Release Checklist:**
 1. All PRs for release are merged to main
 2. All tests passing
-3. Changelog/release notes prepared (if applicable)
+3. Release-notes section for the new version added to `RELEASE_NOTES.md` (or `CHANGELOG.md`)
+4. `KNOWN_ISSUES.md` reflects current state (see Documentation Standard for the canonical file roster)
 
 **Creating the Release:**
-See Version Control Standard for tagging process and mechanics.
+1. Tag the release on main (see Version Control Standard for tagging process and mechanics)
+2. Publish a GitHub Release against the tag, with body mirroring the new release-notes section
+
+The release-notes file and the GitHub Release are BOTH mandatory for every release — see Version Control Standard "Release Notes & GitHub Release" for the rationale and content requirements.
 
 ---
 
@@ -90,7 +120,8 @@ Hotfixes are emergency fixes for production issues.
 2. Branch from production tag, NOT main (see Version Control Standard for branching rules)
 3. Make minimal fix only
 4. Create urgent PR to main
-5. After merge, release immediately
+5. Add a one-line entry to `RELEASE_NOTES.md` (or `CHANGELOG.md`) for the hotfix version
+6. After merge, tag the release and publish a GitHub Release (release-notes + GH Release rule still applies — see Version Control Standard)
 
 **Hotfix Rules:**
 - Minimal changes only — fix the issue, nothing else
@@ -102,10 +133,12 @@ Hotfixes are emergency fixes for production issues.
 ## Anti-Patterns (FORBIDDEN)
 
 - **Working without an issue** — All work must be tracked
+- **Investigating on main** — Even "just looking" must happen on a feature branch
 - **Starting code before branching** — Branch first, then investigate
 - **Bypassing process for "quick fixes"** — Process applies to all changes
 - **Combining unrelated work** — One issue per branch (unless explicitly instructed)
 - **Releasing without clean main** — All changes must be merged first
+- **Releasing without release notes or GitHub Release** — Both are mandatory for every release (see Version Control Standard)
 - **Leaving docs outdated** — Documentation must reflect current code
 
 ---

--- a/.claude/marr/standards/prj-documentation-standard.md
+++ b/.claude/marr/standards/prj-documentation-standard.md
@@ -28,6 +28,30 @@ triggers:
 3. **Keep content types distinct** because mixed purposes confuse readers
 4. **Update docs when code changes** because outdated docs mislead users
 5. **No AI attribution** because content stands on merit, not origin
+6. **Keep release documentation current** because stale release notes and known issues erode trust
+
+---
+
+## Release Documentation
+
+The following files MUST be kept current at all times, and MUST be updated before creating any new release:
+
+| File | Purpose | Update trigger |
+|---|---|---|
+| `README.md` | Project overview and getting started | Any change to project structure, setup steps, or features |
+| `docs/README.md` | Docs site landing page | Any change to documentation structure or content |
+| `RELEASE_NOTES.md` | Cumulative changelog by version | Before every release — add the new version section |
+| `KNOWN_ISSUES.md` | Active issues and limitations | When issues are discovered, resolved, or planned for a release |
+
+**Before creating a release:**
+- [ ] `RELEASE_NOTES.md` has a section for the new version with all changes
+- [ ] `KNOWN_ISSUES.md` reflects current state — new issues added, resolved issues noted
+- [ ] `README.md` releases table includes the new version
+- [ ] `docs/README.md` release references are current
+
+`RELEASE_NOTES.md` and `CHANGELOG.md` serve the same purpose; pick one name per project and stay consistent. Projects already using `CHANGELOG.md` MAY keep that name — the file's role is unchanged.
+
+See Version Control Standard for the release process steps that consume these files (tag, GitHub Release).
 
 ---
 
@@ -88,3 +112,4 @@ All project documentation MUST be organized by user role, then by content type w
 - **Mixing content types** — How-to guides with theory, reference that teaches, explanations with procedures
 - **Leaving stale docs** — Update or remove, never ignore
 - **Creating redundant docs** — One authoritative source per topic
+- **Releasing without updating release docs** — `RELEASE_NOTES.md` (or `CHANGELOG.md`), `KNOWN_ISSUES.md`, and READMEs must be current before any release

--- a/.claude/marr/standards/prj-version-control-standard.md
+++ b/.claude/marr/standards/prj-version-control-standard.md
@@ -25,6 +25,7 @@ triggers:
 4. **Branch from main only** (except hotfixes from production tags)
 5. **Use issue-based branch naming** because traceability matters
 6. **Run tests before pushing** because broken code should never reach the remote
+7. **Every release has release notes and a GitHub Release** because users need a discoverable record of what changed
 
 ---
 
@@ -160,21 +161,40 @@ Production releases are created exclusively via tags on the main branch.
 
 **Tag Naming Convention:** `vX.Y.Z` (e.g., `v1.0.0`, `v2.3.1`)
 
-**Manual Release Process:**
+**Release Process (npm projects):**
 1. Ensure you are on main branch: `git checkout main`
 2. Pull latest: `git pull`
 3. Verify clean working directory: `git status`
-4. Verify tests pass
-5. Update version in project files (e.g., `package.json`)
-6. Commit version bump: `git commit -am "vX.Y.Z"`
-7. Create annotated tag: `git tag -a vX.Y.Z -m "vX.Y.Z"`
-8. Push commit and tag: `git push && git push --tags`
+4. Run tests: `npm test`
+5. Bump version, commit, and tag atomically: `npm version patch` (or `minor`/`major`)
+6. Push commit and tag: `git push && git push --tags`
+
+**Why `npm version`:** Handles version bump, commit, and tag atomically—fewer manual steps, less error-prone.
 
 **Rules:**
 - Tags are immutable — never delete or move a release tag
 - Only tag from main branch
 - Version bump commit should contain only version changes
 - Use annotated tags (`-a`), not lightweight tags
+- For non-npm projects, use equivalent tooling or manual steps
+
+### Release Notes & GitHub Release (MANDATORY)
+
+Every tagged release MUST be accompanied by **both**:
+
+1. **An updated release-notes file** — `RELEASE_NOTES.md` or `CHANGELOG.md` (see Documentation Standard for the canonical file roster). The new version's section MUST exist BEFORE the tag is created. The version-bump commit, the section addition, and the tag MUST point at the same source-tree state.
+
+2. **A GitHub Release** — created against the pushed tag, with the Release body mirroring the new section in the release-notes file. The Release MUST be published promptly after the tag is pushed.
+
+**Why both:** the in-repo file is the canonical, versioned, diffable history that lives with the code. The GitHub Release is the discoverable surface — appears in the repo sidebar, drives release-watcher tooling on npm and elsewhere, and notifies subscribers. Neither is a substitute for the other.
+
+**Content guidance for the release-notes section:**
+- Group changes by type — Added / Changed / Fixed / Removed / Security — in that order
+- Each entry MUST be user-visible (a behaviour, capability, or contract change). Internal refactors that change no observable behaviour DO NOT belong here.
+- Each entry MUST link to its issue or PR number for traceability
+- Breaking changes MUST be flagged at the top of the section
+
+**Hotfix releases:** see Hotfix Workflow in Development Workflow Standard. Hotfix releases follow the same release-notes + GitHub Release rule — a one-line "fix X (closes #N)" entry is sufficient, but the entry MUST exist.
 
 ---
 
@@ -188,6 +208,8 @@ Production releases are created exclusively via tags on the main branch.
 - **Skipping CI checks** — All checks must pass before merge
 - **Issue numbers in commits** — Branch names provide traceability
 - **Pushing without running tests** — Verify locally before pushing
+- **Tagging without release notes** — Every tag MUST have a corresponding section in the release-notes file
+- **Tag pushed without GitHub Release** — A tag without a published GitHub Release is incomplete
 
 ---
 

--- a/resources/project/common/prj-development-workflow-standard.md
+++ b/resources/project/common/prj-development-workflow-standard.md
@@ -100,10 +100,14 @@ Before starting any work:
 **Release Checklist:**
 1. All PRs for release are merged to main
 2. All tests passing
-3. Changelog/release notes prepared (if applicable)
+3. Release-notes section for the new version added to `RELEASE_NOTES.md` (or `CHANGELOG.md`)
+4. `KNOWN_ISSUES.md` reflects current state (see Documentation Standard for the canonical file roster)
 
 **Creating the Release:**
-See Version Control Standard for tagging process and mechanics.
+1. Tag the release on main (see Version Control Standard for tagging process and mechanics)
+2. Publish a GitHub Release against the tag, with body mirroring the new release-notes section
+
+The release-notes file and the GitHub Release are BOTH mandatory for every release — see Version Control Standard "Release Notes & GitHub Release" for the rationale and content requirements.
 
 ---
 
@@ -116,7 +120,8 @@ Hotfixes are emergency fixes for production issues.
 2. Branch from production tag, NOT main (see Version Control Standard for branching rules)
 3. Make minimal fix only
 4. Create urgent PR to main
-5. After merge, release immediately
+5. Add a one-line entry to `RELEASE_NOTES.md` (or `CHANGELOG.md`) for the hotfix version
+6. After merge, tag the release and publish a GitHub Release (release-notes + GH Release rule still applies — see Version Control Standard)
 
 **Hotfix Rules:**
 - Minimal changes only — fix the issue, nothing else
@@ -133,6 +138,7 @@ Hotfixes are emergency fixes for production issues.
 - **Bypassing process for "quick fixes"** — Process applies to all changes
 - **Combining unrelated work** — One issue per branch (unless explicitly instructed)
 - **Releasing without clean main** — All changes must be merged first
+- **Releasing without release notes or GitHub Release** — Both are mandatory for every release (see Version Control Standard)
 - **Leaving docs outdated** — Documentation must reflect current code
 
 ---

--- a/resources/project/common/prj-documentation-standard.md
+++ b/resources/project/common/prj-documentation-standard.md
@@ -28,6 +28,30 @@ triggers:
 3. **Keep content types distinct** because mixed purposes confuse readers
 4. **Update docs when code changes** because outdated docs mislead users
 5. **No AI attribution** because content stands on merit, not origin
+6. **Keep release documentation current** because stale release notes and known issues erode trust
+
+---
+
+## Release Documentation
+
+The following files MUST be kept current at all times, and MUST be updated before creating any new release:
+
+| File | Purpose | Update trigger |
+|---|---|---|
+| `README.md` | Project overview and getting started | Any change to project structure, setup steps, or features |
+| `docs/README.md` | Docs site landing page | Any change to documentation structure or content |
+| `RELEASE_NOTES.md` | Cumulative changelog by version | Before every release — add the new version section |
+| `KNOWN_ISSUES.md` | Active issues and limitations | When issues are discovered, resolved, or planned for a release |
+
+**Before creating a release:**
+- [ ] `RELEASE_NOTES.md` has a section for the new version with all changes
+- [ ] `KNOWN_ISSUES.md` reflects current state — new issues added, resolved issues noted
+- [ ] `README.md` releases table includes the new version
+- [ ] `docs/README.md` release references are current
+
+`RELEASE_NOTES.md` and `CHANGELOG.md` serve the same purpose; pick one name per project and stay consistent. Projects already using `CHANGELOG.md` MAY keep that name — the file's role is unchanged.
+
+See Version Control Standard for the release process steps that consume these files (tag, GitHub Release).
 
 ---
 
@@ -88,3 +112,4 @@ All project documentation MUST be organized by user role, then by content type w
 - **Mixing content types** — How-to guides with theory, reference that teaches, explanations with procedures
 - **Leaving stale docs** — Update or remove, never ignore
 - **Creating redundant docs** — One authoritative source per topic
+- **Releasing without updating release docs** — `RELEASE_NOTES.md` (or `CHANGELOG.md`), `KNOWN_ISSUES.md`, and READMEs must be current before any release

--- a/resources/project/common/prj-version-control-standard.md
+++ b/resources/project/common/prj-version-control-standard.md
@@ -25,6 +25,7 @@ triggers:
 4. **Branch from main only** (except hotfixes from production tags)
 5. **Use issue-based branch naming** because traceability matters
 6. **Run tests before pushing** because broken code should never reach the remote
+7. **Every release has release notes and a GitHub Release** because users need a discoverable record of what changed
 
 ---
 
@@ -177,6 +178,24 @@ Production releases are created exclusively via tags on the main branch.
 - Use annotated tags (`-a`), not lightweight tags
 - For non-npm projects, use equivalent tooling or manual steps
 
+### Release Notes & GitHub Release (MANDATORY)
+
+Every tagged release MUST be accompanied by **both**:
+
+1. **An updated release-notes file** — `RELEASE_NOTES.md` or `CHANGELOG.md` (see Documentation Standard for the canonical file roster). The new version's section MUST exist BEFORE the tag is created. The version-bump commit, the section addition, and the tag MUST point at the same source-tree state.
+
+2. **A GitHub Release** — created against the pushed tag, with the Release body mirroring the new section in the release-notes file. The Release MUST be published promptly after the tag is pushed.
+
+**Why both:** the in-repo file is the canonical, versioned, diffable history that lives with the code. The GitHub Release is the discoverable surface — appears in the repo sidebar, drives release-watcher tooling on npm and elsewhere, and notifies subscribers. Neither is a substitute for the other.
+
+**Content guidance for the release-notes section:**
+- Group changes by type — Added / Changed / Fixed / Removed / Security — in that order
+- Each entry MUST be user-visible (a behaviour, capability, or contract change). Internal refactors that change no observable behaviour DO NOT belong here.
+- Each entry MUST link to its issue or PR number for traceability
+- Breaking changes MUST be flagged at the top of the section
+
+**Hotfix releases:** see Hotfix Workflow in Development Workflow Standard. Hotfix releases follow the same release-notes + GitHub Release rule — a one-line "fix X (closes #N)" entry is sufficient, but the entry MUST exist.
+
 ---
 
 ## Anti-Patterns (FORBIDDEN)
@@ -189,6 +208,8 @@ Production releases are created exclusively via tags on the main branch.
 - **Skipping CI checks** — All checks must pass before merge
 - **Issue numbers in commits** — Branch names provide traceability
 - **Pushing without running tests** — Verify locally before pushing
+- **Tagging without release notes** — Every tag MUST have a corresponding section in the release-notes file
+- **Tag pushed without GitHub Release** — A tag without a published GitHub Release is incomplete
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #89.

Adds release-documentation and GitHub-Release requirements to three project standards:

- **`prj-documentation-standard.md`** — Adds a canonical release-doc file roster (`README.md`, `docs/README.md`, `RELEASE_NOTES.md`, `KNOWN_ISSUES.md`) with a pre-release checklist. Notes that `RELEASE_NOTES.md` and `CHANGELOG.md` are interchangeable; pick one per project.
- **`prj-version-control-standard.md`** — New core principle (every release has release notes and a GitHub Release). New "Release Notes & GitHub Release (MANDATORY)" section requiring **both** an in-repo release-notes file and a published GitHub Release for every tagged release, with content guidance and hotfix rules. Two new anti-patterns.
- **`prj-development-workflow-standard.md`** — Tightens the Release Checklist (drops `(if applicable)`), adds a GitHub-Release step under "Creating the Release", adds a release-notes entry to the hotfix workflow, adds an anti-pattern. Cross-references the version-control standard for detail.

The three standards form a closed loop: the workflow points at the version-control standard for the rule, the version-control standard points at the documentation standard for the canonical file roster, and the documentation standard points at the version-control standard for the release-process steps that consume those files.

## Regen

`.claude/marr/standards/` is the dogfooded copy of `resources/project/common/`. The three modified files have been regenerated so this repo runs on its own updated standards. Pre-existing drift in `prj-development-workflow-standard.md` (missing STOP-GATE section, three trigger lines, one anti-pattern) and `prj-version-control-standard.md` is also resolved as a side-effect.

## Test plan

- [ ] CI passes
- [ ] Verify each `.claude/marr/standards/` file is byte-equal to its `resources/project/common/` counterpart
- [ ] Read each updated standard end-to-end and confirm the three cross-references resolve
- [ ] Confirm no other files in `.claude/marr/` were changed