### PR TITLE
Fix marr init writing wrong import path for .claude/CLAUDE.md (#106)

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -7,7 +7,6 @@ This file lists active bugs and known limitations. For new features and roadmap 
 | # | Issue | Affects | Workaround |
 |---|---|---|---|
 | [#85](https://github.com/virtualian/marr/issues/85) | `marr standard list` only lists locally-installed standards, not all available standards | `marr standard list` | Use `marr init --project --standards list` to see available bundled standards |
-| [#106](https://github.com/virtualian/marr/issues/106) | `marr init` writes incorrect import path when project uses `.claude/CLAUDE.md` location | `marr init --project` on projects with non-root CLAUDE.md | Manually correct the import line after init |
 
 ## Known Limitations
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,9 @@ This file is the canonical, in-repo history. Each section is mirrored in a corre
 ### Added
 - Mandate release notes and GitHub Release for every tagged release ([#112](https://github.com/virtualian/marr/pull/112), closes [#89](https://github.com/virtualian/marr/issues/89))
 
+### Fixed
+- `marr init --project` now writes the correct import line when the project uses `./.claude/CLAUDE.md` instead of `./CLAUDE.md`. Previously the hardcoded `@.claude/marr/MARR-PROJECT-CLAUDE.md` form was written into both locations, silently failing to resolve from the dotclaude location. `clean`, `validate`, `doctor`, and conflict detection are now location-aware (closes [#106](https://github.com/virtualian/marr/issues/106)).
+
 ### Security
 - Override `brace-expansion` to fix transitive ReDoS ([#110](https://github.com/virtualian/marr/pull/110))
 - Bump `yaml` from 2.8.1 to 2.8.3 ([#104](https://github.com/virtualian/marr/pull/104))

--- a/docs/dev/explanation/specification.md
+++ b/docs/dev/explanation/specification.md
@@ -79,11 +79,18 @@ MARR integrates with Claude Code via markdown imports:
 ~/.claude/CLAUDE.md
   └── @~/.claude/marr/MARR-USER-CLAUDE.md    (user config)
 
-./CLAUDE.md
+./CLAUDE.md                                  (project at root)
   └── @.claude/marr/MARR-PROJECT-CLAUDE.md   (project config)
+
+./.claude/CLAUDE.md                          (project under .claude/)
+  └── @marr/MARR-PROJECT-CLAUDE.md           (project config)
 ```
 
-Claude Code reads `CLAUDE.md` files and follows import directives. MARR uses this mechanism rather than inventing a new one.
+Claude Code resolves `@path` imports relative to the file containing them, so
+the project import line differs by CLAUDE.md location. `marr init --project`
+detects which location is in use and writes the matching form.
+
+MARR uses this import mechanism rather than inventing a new one.
 
 ## System Boundaries
 

--- a/docs/user/explanation/configuration.md
+++ b/docs/user/explanation/configuration.md
@@ -83,10 +83,18 @@ When an AI agent's task matches a trigger, it reads that standard before proceed
 
 ### Loading Mechanism
 
-Project configuration loads through:
-1. `./CLAUDE.md` contains `@.claude/marr/MARR-PROJECT-CLAUDE.md`
-2. This import brings in the project's MARR config
-3. Standards are read on-demand based on trigger conditions
+Project configuration loads through a `CLAUDE.md` import. Claude Code resolves
+`@path` imports relative to the file containing them, so the exact import string
+depends on which CLAUDE.md location your project uses:
+
+| CLAUDE.md location | Import line |
+|--------------------|-------------|
+| `./CLAUDE.md`      | `@.claude/marr/MARR-PROJECT-CLAUDE.md` |
+| `./.claude/CLAUDE.md` | `@marr/MARR-PROJECT-CLAUDE.md` |
+
+`marr init --project` writes the correct form for whichever location it finds
+(or creates `./CLAUDE.md` by default). The import brings in the project's MARR
+config, and standards are read on-demand based on trigger conditions.
 
 ## Configuration Hierarchy
 

--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -9,6 +9,10 @@ import { join } from 'path';
 import * as fileOps from '../utils/file-ops.js';
 import * as logger from '../utils/logger.js';
 import { removeMarrImport, isMarrSetup, hasMarrImport } from '../utils/marr-setup.js';
+import {
+  MARR_PROJECT_IMPORT_COMMENT,
+  getAllMarrProjectImportLines,
+} from '../utils/marr-import.js';
 
 interface CleanOptions {
   user: boolean;
@@ -58,12 +62,17 @@ function cleanUser(dryRun: boolean): { removed: string[]; errors: string[] } {
   return { removed, errors };
 }
 
-/** MARR import line in project CLAUDE.md */
-const MARR_PROJECT_IMPORT_LINE = '@.claude/marr/MARR-PROJECT-CLAUDE.md';
-const MARR_PROJECT_IMPORT_COMMENT = '<!-- MARR: Making Agents Really Reliable -->';
+/**
+ * Find which (if any) MARR project import form is present in content.
+ */
+function findProjectImport(content: string): string | undefined {
+  return getAllMarrProjectImportLines().find(form => content.includes(form));
+}
 
 /**
- * Clean project-level MARR configuration (./.claude/marr/ and import from CLAUDE.md)
+ * Clean project-level MARR configuration (./.claude/marr/ and import from CLAUDE.md).
+ *
+ * Recognises every known import form so legacy installs (#106) remain cleanable.
  */
 function cleanProject(dryRun: boolean): { removed: string[]; errors: string[] } {
   const removed: string[] = [];
@@ -74,7 +83,6 @@ function cleanProject(dryRun: boolean): { removed: string[]; errors: string[] } 
   const rootClaudeMdPath = join(cwd, 'CLAUDE.md');
   const dotClaudeClaudeMdPath = join(cwd, '.claude', 'CLAUDE.md');
 
-  // Remove ./.claude/marr/ directory if it exists
   if (fileOps.exists(marrPath) && fileOps.isDirectory(marrPath)) {
     if (dryRun) {
       removed.push('./.claude/marr/ directory');
@@ -88,34 +96,32 @@ function cleanProject(dryRun: boolean): { removed: string[]; errors: string[] } 
     }
   }
 
-  // Remove MARR import from CLAUDE.md (check both locations)
   const claudeMdPaths = [
     { path: rootClaudeMdPath, label: './CLAUDE.md' },
     { path: dotClaudeClaudeMdPath, label: './.claude/CLAUDE.md' },
   ];
 
   for (const { path: claudeMdPath, label } of claudeMdPaths) {
-    if (fileOps.exists(claudeMdPath)) {
-      const content = fileOps.readFile(claudeMdPath);
-      if (content.includes(MARR_PROJECT_IMPORT_LINE)) {
-        if (dryRun) {
-          removed.push(`MARR import from ${label}`);
-        } else {
-          try {
-            let newContent = content;
-            // Remove import block (comment + import line)
-            newContent = newContent.replace(MARR_PROJECT_IMPORT_COMMENT + '\n', '');
-            newContent = newContent.replace(MARR_PROJECT_IMPORT_LINE + '\n', '');
-            newContent = newContent.replace(MARR_PROJECT_IMPORT_LINE, '');
-            // Clean up extra blank lines
-            newContent = newContent.replace(/\n{3,}/g, '\n\n');
-            fileOps.writeFile(claudeMdPath, newContent);
-            removed.push(`MARR import from ${label}`);
-          } catch (err) {
-            errors.push(`Failed to remove MARR import from ${label}: ${(err as Error).message}`);
-          }
-        }
-      }
+    if (!fileOps.exists(claudeMdPath)) continue;
+    const content = fileOps.readFile(claudeMdPath);
+    const importLine = findProjectImport(content);
+    if (!importLine) continue;
+
+    if (dryRun) {
+      removed.push(`MARR import from ${label}`);
+      continue;
+    }
+
+    try {
+      let newContent = content;
+      newContent = newContent.replace(MARR_PROJECT_IMPORT_COMMENT + '\n', '');
+      newContent = newContent.replace(importLine + '\n', '');
+      newContent = newContent.replace(importLine, '');
+      newContent = newContent.replace(/\n{3,}/g, '\n\n');
+      fileOps.writeFile(claudeMdPath, newContent);
+      removed.push(`MARR import from ${label}`);
+    } catch (err) {
+      errors.push(`Failed to remove MARR import from ${label}: ${(err as Error).message}`);
     }
   }
 
@@ -139,9 +145,9 @@ function executeClean(options: CleanOptions): void {
   const cwd = process.cwd();
   const hasMarrDir = fileOps.exists(join(cwd, '.claude', 'marr'));
   const rootClaudeMdHasImport = fileOps.exists(join(cwd, 'CLAUDE.md')) &&
-    fileOps.readFile(join(cwd, 'CLAUDE.md')).includes(MARR_PROJECT_IMPORT_LINE);
+    findProjectImport(fileOps.readFile(join(cwd, 'CLAUDE.md'))) !== undefined;
   const dotClaudeClaudeMdHasImport = fileOps.exists(join(cwd, '.claude', 'CLAUDE.md')) &&
-    fileOps.readFile(join(cwd, '.claude', 'CLAUDE.md')).includes(MARR_PROJECT_IMPORT_LINE);
+    findProjectImport(fileOps.readFile(join(cwd, '.claude', 'CLAUDE.md'))) !== undefined;
   const projectHasContent = hasMarrDir || rootClaudeMdHasImport || dotClaudeClaudeMdHasImport;
 
   if (cleanUserConfig && !userHasContent && cleanProjectConfig && !projectHasContent) {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -13,6 +13,12 @@ import {
   detectProjectConflicts,
   detectUserConflicts,
 } from '../utils/conflict-detector.js';
+import { getMarrImportLine } from '../utils/marr-setup.js';
+import {
+  MARR_PROJECT_IMPORT_COMMENT,
+  classifyClaudeMdPath,
+  getMarrProjectImportLine,
+} from '../utils/marr-import.js';
 import type {
   Conflict,
   Resolution,
@@ -270,16 +276,16 @@ async function applyResolution(
 async function addMissingImport(conflict: Conflict): Promise<void> {
   const content = fileOps.readFile(conflict.location);
 
-  // Determine which import to add based on location
-  const isUserConfig = conflict.location.includes('.claude/CLAUDE.md') &&
-    conflict.location.includes(fileOps.getHomeDir());
+  // Distinguish user vs project by exact-path equality. Substring checks for
+  // `.claude/CLAUDE.md` + the home directory misclassify any project that
+  // lives under $HOME and uses the dotclaude CLAUDE.md location.
+  const isUserConfig = conflict.location === fileOps.getUserClaudeMdPath();
 
   const importLine = isUserConfig
-    ? '@~/.claude/marr/MARR-USER-CLAUDE.md'
-    : '@.claude/marr/MARR-PROJECT-CLAUDE.md';
+    ? getMarrImportLine()
+    : getMarrProjectImportLine(classifyClaudeMdPath(conflict.location));
 
-  const importComment = '<!-- MARR: Making Agents Really Reliable -->';
-  const importBlock = `${importComment}\n${importLine}\n`;
+  const importBlock = `${MARR_PROJECT_IMPORT_COMMENT}\n${importLine}\n`;
 
   // Add after first heading or at top
   const lines = content.split('\n');

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -15,6 +15,12 @@ import * as logger from '../utils/logger.js';
 import * as fileOps from '../utils/file-ops.js';
 import * as marrSetup from '../utils/marr-setup.js';
 import { registerProject } from '../utils/project-registry.js';
+import {
+  MARR_PROJECT_IMPORT_COMMENT,
+  classifyClaudeMdPath,
+  getAllMarrProjectImportLines,
+  getMarrProjectImportLine,
+} from '../utils/marr-import.js';
 
 interface InitOptions {
   user: boolean;
@@ -446,10 +452,6 @@ async function selectStandards(availableStandards: StandardInfo[]): Promise<Stan
   return selected;
 }
 
-/** MARR import line for project CLAUDE.md */
-const MARR_PROJECT_IMPORT_LINE = '@.claude/marr/MARR-PROJECT-CLAUDE.md';
-const MARR_PROJECT_IMPORT_COMMENT = '<!-- MARR: Making Agents Really Reliable -->';
-
 /**
  * Copy MARR-PROJECT-CLAUDE.md template to .claude/marr/
  */
@@ -491,7 +493,10 @@ This directory contains MARR (Making Agents Really Reliable) configuration for t
 
 ## How It Works
 
-1. Project root \`CLAUDE.md\` imports \`@.claude/marr/MARR-PROJECT-CLAUDE.md\`
+1. The project's \`CLAUDE.md\` imports \`MARR-PROJECT-CLAUDE.md\` from this directory.
+   The import line depends on which CLAUDE.md location the project uses:
+   - \`./CLAUDE.md\` → \`@.claude/marr/MARR-PROJECT-CLAUDE.md\`
+   - \`./.claude/CLAUDE.md\` → \`@marr/MARR-PROJECT-CLAUDE.md\`
 2. MARR-PROJECT-CLAUDE.md defines trigger conditions for standards
 3. When a trigger is met, the AI agent reads that standard before proceeding
 
@@ -534,49 +539,65 @@ function copyProjectStandards(standardsPath: string, selectedStandards: Standard
 }
 
 /**
- * Add MARR import to project root CLAUDE.md
- * Creates file if it doesn't exist, adds import if it does
+ * Add MARR import to project CLAUDE.md.
+ *
+ * The chosen import string depends on which CLAUDE.md location is in use:
+ * imports resolve relative to the file containing them, so a CLAUDE.md sat
+ * at `<project>/.claude/CLAUDE.md` needs `@marr/...`, while one at
+ * `<project>/CLAUDE.md` needs `@.claude/marr/...`.
+ *
+ * Creates the file if it doesn't exist. If it exists with a stale
+ * wrong-for-location form (legacy installs predating #106), replaces it.
  */
 function addProjectClaudeMdImport(claudeMdPath: string, targetDir: string): void {
-  const projectName = targetDir.split('/').pop() || 'Project';
+  const projectName = basename(targetDir) || 'Project';
+  const location = classifyClaudeMdPath(claudeMdPath);
+  const importLine = getMarrProjectImportLine(location);
+  const filename = basename(claudeMdPath);
 
   if (!fileOps.exists(claudeMdPath)) {
-    // Create new CLAUDE.md with MARR import
     const content = `# ${projectName}
 
 ${MARR_PROJECT_IMPORT_COMMENT}
-${MARR_PROJECT_IMPORT_LINE}
+${importLine}
 
 Add project-specific Claude Code configuration here.
 `;
     fileOps.writeFile(claudeMdPath, content);
-    logger.success('Created: CLAUDE.md with MARR import');
+    logger.success(`Created: ${filename} with MARR import`);
     return;
   }
 
-  // File exists - check if import already present
   const existingContent = fileOps.readFile(claudeMdPath);
-  if (existingContent.includes(MARR_PROJECT_IMPORT_LINE)) {
-    logger.info('MARR import already present in CLAUDE.md');
+  if (existingContent.includes(importLine)) {
+    logger.info(`MARR import already present in ${filename}`);
     return;
   }
 
-  // Add import after first heading or at top
+  // Replace any wrong-for-location form left behind by a legacy install
+  const staleForm = getAllMarrProjectImportLines().find(
+    form => form !== importLine && existingContent.includes(form)
+  );
+  if (staleForm) {
+    const replaced = existingContent.replace(staleForm, importLine);
+    fileOps.writeFile(claudeMdPath, replaced);
+    logger.success(`Updated MARR import in ${filename} (was: ${staleForm})`);
+    return;
+  }
+
   const lines = existingContent.split('\n');
   const firstHeadingIndex = lines.findIndex(line => line.startsWith('# '));
 
-  const importBlock = `\n${MARR_PROJECT_IMPORT_COMMENT}\n${MARR_PROJECT_IMPORT_LINE}\n`;
+  const importBlock = `\n${MARR_PROJECT_IMPORT_COMMENT}\n${importLine}\n`;
 
   let newContent: string;
   if (firstHeadingIndex >= 0) {
-    // Insert after first heading
     lines.splice(firstHeadingIndex + 1, 0, importBlock);
     newContent = lines.join('\n');
   } else {
-    // Prepend to file
     newContent = importBlock + '\n' + existingContent;
   }
 
   fileOps.writeFile(claudeMdPath, newContent);
-  logger.success('Added: MARR import to CLAUDE.md');
+  logger.success(`Added: MARR import to ${filename}`);
 }

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -10,6 +10,7 @@ import { join } from 'path';
 import * as logger from '../utils/logger.js';
 import * as fileOps from '../utils/file-ops.js';
 import { detectProjectConflicts } from '../utils/conflict-detector.js';
+import { classifyClaudeMdPath, getMarrProjectImportLine } from '../utils/marr-import.js';
 import type { Conflict } from '../types/conflict.js';
 
 interface ValidateOptions {
@@ -359,9 +360,7 @@ function validateStandardNaming(result: ValidationResult): void {
 function validateRootClaudeMd(result: ValidationResult): void {
   const rootClaudeMdPath = join(process.cwd(), 'CLAUDE.md');
   const dotClaudeClaudeMdPath = join(process.cwd(), '.claude', 'CLAUDE.md');
-  const importLine = '@.claude/marr/MARR-PROJECT-CLAUDE.md';
 
-  // Check both possible CLAUDE.md locations
   let claudeMdPath: string | null = null;
   let location = '';
 
@@ -380,6 +379,7 @@ function validateRootClaudeMd(result: ValidationResult): void {
     return;
   }
 
+  const importLine = getMarrProjectImportLine(classifyClaudeMdPath(claudeMdPath));
   const content = fileOps.readFile(claudeMdPath);
 
   if (!content.includes(importLine)) {

--- a/src/utils/conflict-detector.test.ts
+++ b/src/utils/conflict-detector.test.ts
@@ -179,6 +179,86 @@ triggers:
     assert.ok(directiveConflicts.length > 0, 'Should detect anti-pattern violation');
   });
 
+  it('does not flag missing import when .claude/CLAUDE.md uses sibling-relative form (#106)', () => {
+    createStandard(
+      tempDir,
+      'prj-testing-standard.md',
+      `---
+marr: standard
+version: 1
+title: Testing Standard
+scope: All testing activities
+triggers:
+  - WHEN running tests
+---
+
+## Core Rules
+
+1. **Run tests** always
+`
+    );
+
+    // Use the .claude/CLAUDE.md location with the correct sibling-relative import.
+    // Remove the root CLAUDE.md so the .claude/ one is what gets discovered.
+    rmSync(join(tempDir, 'CLAUDE.md'), { force: true });
+    writeFileSync(
+      join(tempDir, '.claude', 'CLAUDE.md'),
+      `# Project Configuration
+
+@marr/MARR-PROJECT-CLAUDE.md
+
+Some project rules.
+`
+    );
+
+    const conflicts = detectProjectConflicts(tempDir);
+    const missingImportConflicts = conflicts.filter(c => c.category === 'missing_import');
+    assert.strictEqual(
+      missingImportConflicts.length,
+      0,
+      'Should accept @marr/MARR-PROJECT-CLAUDE.md as the correct form for .claude/CLAUDE.md'
+    );
+  });
+
+  it('flags missing import when .claude/CLAUDE.md uses the wrong (legacy) form', () => {
+    createStandard(
+      tempDir,
+      'prj-testing-standard.md',
+      `---
+marr: standard
+version: 1
+title: Testing Standard
+scope: All testing activities
+triggers:
+  - WHEN running tests
+---
+
+## Core Rules
+
+1. **Run tests** always
+`
+    );
+
+    rmSync(join(tempDir, 'CLAUDE.md'), { force: true });
+    writeFileSync(
+      join(tempDir, '.claude', 'CLAUDE.md'),
+      `# Project Configuration
+
+@.claude/marr/MARR-PROJECT-CLAUDE.md
+
+Legacy broken form — does not resolve from this location.
+`
+    );
+
+    const conflicts = detectProjectConflicts(tempDir);
+    const missingImportConflicts = conflicts.filter(c => c.category === 'missing_import');
+    assert.strictEqual(
+      missingImportConflicts.length,
+      1,
+      'Should flag the legacy broken form as missing the correct import'
+    );
+  });
+
   it('detects missing MARR import', () => {
     // Create standards
     createStandard(

--- a/src/utils/conflict-detector.ts
+++ b/src/utils/conflict-detector.ts
@@ -19,6 +19,7 @@ import {
   getTransitiveImports,
   type ConfigFile,
 } from './config-scanner.js';
+import { classifyClaudeMdPath, getMarrProjectImportLine } from './marr-import.js';
 import type {
   Conflict,
   ConflictReport,
@@ -26,9 +27,8 @@ import type {
   Resolution,
 } from '../types/conflict.js';
 
-/** MARR import markers */
+/** MARR import marker for the user-level CLAUDE.md */
 const MARR_USER_IMPORT = '@~/.claude/marr/MARR-USER-CLAUDE.md';
-const MARR_PROJECT_IMPORT = '@.claude/marr/MARR-PROJECT-CLAUDE.md';
 
 /** Minimum keyword overlap to consider a potential conflict */
 const MIN_KEYWORD_OVERLAP = 2;
@@ -461,9 +461,10 @@ export function detectProjectConflicts(projectDir: string = process.cwd()): Conf
       ? dotClaudeClaudeMdPath
       : null;
 
-  // Check for missing import
+  // Check for missing import — expected form depends on which CLAUDE.md location is used
   if (claudeMdPath) {
-    const missingImport = checkMissingImport(claudeMdPath, MARR_PROJECT_IMPORT, 'project');
+    const expectedImport = getMarrProjectImportLine(classifyClaudeMdPath(claudeMdPath));
+    const missingImport = checkMissingImport(claudeMdPath, expectedImport, 'project');
     if (missingImport) {
       conflicts.push(missingImport);
     }

--- a/src/utils/marr-import.test.ts
+++ b/src/utils/marr-import.test.ts
@@ -1,0 +1,64 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  classifyClaudeMdPath,
+  getMarrProjectImportLine,
+  getAllMarrProjectImportLines,
+  MARR_PROJECT_IMPORT_COMMENT,
+} from './marr-import.js';
+
+describe('classifyClaudeMdPath', () => {
+  it('classifies root CLAUDE.md as root', () => {
+    assert.strictEqual(classifyClaudeMdPath('/x/CLAUDE.md'), 'root');
+    assert.strictEqual(classifyClaudeMdPath('/Users/me/projects/foo/CLAUDE.md'), 'root');
+  });
+
+  it('classifies .claude/CLAUDE.md as dotclaude', () => {
+    assert.strictEqual(classifyClaudeMdPath('/x/.claude/CLAUDE.md'), 'dotclaude');
+    assert.strictEqual(
+      classifyClaudeMdPath('/Users/me/projects/foo/.claude/CLAUDE.md'),
+      'dotclaude'
+    );
+  });
+
+  it('classifies bare CLAUDE.md (no parent dir) as root', () => {
+    assert.strictEqual(classifyClaudeMdPath('CLAUDE.md'), 'root');
+  });
+
+  it('does not misclassify deeper paths whose parent is not .claude', () => {
+    assert.strictEqual(classifyClaudeMdPath('/x/.claude/sub/CLAUDE.md'), 'root');
+  });
+});
+
+describe('getMarrProjectImportLine', () => {
+  it('returns root form for root location', () => {
+    assert.strictEqual(
+      getMarrProjectImportLine('root'),
+      '@.claude/marr/MARR-PROJECT-CLAUDE.md'
+    );
+  });
+
+  it('returns sibling-relative form for dotclaude location', () => {
+    assert.strictEqual(
+      getMarrProjectImportLine('dotclaude'),
+      '@marr/MARR-PROJECT-CLAUDE.md'
+    );
+  });
+});
+
+describe('getAllMarrProjectImportLines', () => {
+  it('contains both forms', () => {
+    const lines = getAllMarrProjectImportLines();
+    assert.ok(lines.includes('@.claude/marr/MARR-PROJECT-CLAUDE.md'));
+    assert.ok(lines.includes('@marr/MARR-PROJECT-CLAUDE.md'));
+  });
+});
+
+describe('MARR_PROJECT_IMPORT_COMMENT', () => {
+  it('is the canonical MARR comment marker', () => {
+    assert.strictEqual(
+      MARR_PROJECT_IMPORT_COMMENT,
+      '<!-- MARR: Making Agents Really Reliable -->'
+    );
+  });
+});

--- a/src/utils/marr-import.ts
+++ b/src/utils/marr-import.ts
@@ -1,0 +1,54 @@
+/**
+ * MARR project import line helpers.
+ *
+ * Claude Code resolves @path imports relative to the file containing them.
+ * The MARR project import line therefore depends on which CLAUDE.md location
+ * the project uses:
+ *
+ *   ./CLAUDE.md          → @.claude/marr/MARR-PROJECT-CLAUDE.md
+ *   ./.claude/CLAUDE.md  → @marr/MARR-PROJECT-CLAUDE.md
+ */
+
+import { basename, dirname } from 'path';
+
+/** Comment marker that precedes the MARR import line in CLAUDE.md */
+export const MARR_PROJECT_IMPORT_COMMENT = '<!-- MARR: Making Agents Really Reliable -->';
+
+/** Which CLAUDE.md location a project uses */
+export type ProjectClaudeMdLocation = 'root' | 'dotclaude';
+
+/**
+ * Classify a CLAUDE.md path by its location relative to the project.
+ *
+ * `dotclaude` means the file lives at `<project>/.claude/CLAUDE.md`.
+ * `root` covers everything else — i.e. `<project>/CLAUDE.md`.
+ */
+export function classifyClaudeMdPath(claudeMdPath: string): ProjectClaudeMdLocation {
+  return basename(dirname(claudeMdPath)) === '.claude' ? 'dotclaude' : 'root';
+}
+
+/**
+ * Return the MARR project import line for the given CLAUDE.md location.
+ */
+export function getMarrProjectImportLine(location: ProjectClaudeMdLocation): string {
+  return location === 'dotclaude'
+    ? '@marr/MARR-PROJECT-CLAUDE.md'
+    : '@.claude/marr/MARR-PROJECT-CLAUDE.md';
+}
+
+const ALL_LOCATIONS: readonly ProjectClaudeMdLocation[] = ['root', 'dotclaude'];
+
+const ALL_IMPORT_LINES: readonly string[] = Object.freeze(
+  ALL_LOCATIONS.map(getMarrProjectImportLine)
+);
+
+/**
+ * Return all MARR project import line forms.
+ *
+ * Used by clean / conflict-detection to recognise an import irrespective of
+ * which CLAUDE.md location wrote it — including legacy installs that wrote
+ * the wrong form into `.claude/CLAUDE.md` before this bug was fixed (#106).
+ */
+export function getAllMarrProjectImportLines(): readonly string[] {
+  return ALL_IMPORT_LINES;
+}

--- a/src/utils/marr-setup.ts
+++ b/src/utils/marr-setup.ts
@@ -9,15 +9,13 @@ import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import * as fileOps from './file-ops.js';
 import * as logger from './logger.js';
+import { MARR_PROJECT_IMPORT_COMMENT as MARR_IMPORT_COMMENT } from './marr-import.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 /** Import line that MARR adds to ~/.claude/CLAUDE.md */
 const MARR_IMPORT_LINE = '@~/.claude/marr/MARR-USER-CLAUDE.md';
-
-/** Comment marker to identify MARR's import */
-const MARR_IMPORT_COMMENT = '<!-- MARR: Making Agents Really Reliable -->';
 
 /** Full import block including comment for easy identification */
 const MARR_IMPORT_BLOCK = `${MARR_IMPORT_COMMENT}\n${MARR_IMPORT_LINE}\n`;


### PR DESCRIPTION
## Summary

Fixes #106. `marr init --project` hardcoded `@.claude/marr/MARR-PROJECT-CLAUDE.md` as the MARR import line, but Claude Code resolves `@path` imports relative to the file containing them. When init wrote that line into `./.claude/CLAUDE.md` (instead of `./CLAUDE.md`) the import resolved to `./.claude/.claude/marr/MARR-PROJECT-CLAUDE.md` and the entire MARR config silently failed to load.

The same hardcoded constant lived in `init`, `clean`, `validate`, `doctor`, and `conflict-detector` — every consumer was silently broken for the dotclaude location.

## Approach

New `src/utils/marr-import.ts` exports:

| Symbol | Purpose |
|---|---|
| `MARR_PROJECT_IMPORT_COMMENT` | Canonical comment marker (now also re-used by `marr-setup.ts`) |
| `ProjectClaudeMdLocation` | `'root' \| 'dotclaude'` |
| `classifyClaudeMdPath(path)` | Pure path-based classifier using `basename(dirname(path)) === '.claude'` |
| `getMarrProjectImportLine(location)` | Returns the correct import string for the location |
| `getAllMarrProjectImportLines()` | Both forms (frozen module-level constant) |

Threaded through every consumer:

- **init.ts** — writes the correct form for the chosen location; on re-run, replaces a stale wrong-for-location form (legacy migration path for projects already hit by #106)
- **clean.ts** — recognises both forms via `findProjectImport`, so legacy installs remain cleanable
- **validate.ts** — checks the correct expected line per location
- **conflict-detector.ts** — same
- **doctor.ts** — uses the helper for project; user-side hardcoding replaced with `marrSetup.getMarrImportLine()`. Also fixes a pre-existing bug where `addMissingImport` distinguished user vs project by substring containment (`'.claude/CLAUDE.md'` + home dir), which misclassifies any project under `$HOME` that uses the dotclaude location. Now uses exact-path equality.

## Tests

- 8 new tests in `src/utils/marr-import.test.ts` covering classifier and getter
- 2 new tests in `src/utils/conflict-detector.test.ts` — one accepting `@marr/...` in `.claude/CLAUDE.md`, one rejecting the legacy broken form there

```
ℹ tests 59
ℹ pass 59
ℹ fail 0
```

`tsc` clean, `npm run lint` clean.

## Docs

- `docs/user/explanation/configuration.md` — both forms shown in a table
- `docs/dev/explanation/specification.md` — Import Mechanism section now covers both project locations
- Init's `createMarrReadme` template — same
- `RELEASE_NOTES.md` Unreleased — Fixed entry
- `KNOWN_ISSUES.md` — #106 row removed

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc` clean
- [x] `npm test` 59/59 pass (8 new helper tests + 2 new conflict-detector tests + 49 pre-existing)
- [ ] Manual: `marr init --project --force` in a directory where only `./.claude/CLAUDE.md` exists writes `@marr/MARR-PROJECT-CLAUDE.md` (not the broken `@.claude/marr/...` form)
- [ ] Manual: re-running `marr init --project --force` on a directory whose `./.claude/CLAUDE.md` already contains the legacy broken `@.claude/marr/...` form rewrites it to `@marr/...`
- [ ] Manual: `marr clean --project` removes either form from either CLAUDE.md location

Closes #106