### PR TITLE
Add marr update command for canonical drift refresh

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -12,8 +12,7 @@ This file lists active bugs and known limitations. For new features and roadmap 
 
 | # | Limitation | Notes |
 |---|---|---|
-| [#86](https://github.com/virtualian/marr/issues/86) | Deprecated, deleted, old, replaced, and stale standards are not removed during sync or upgrade | A subsequent sync re-installs the latest set; orphaned files must be removed manually |
-| [#111](https://github.com/virtualian/marr/issues/111) | Consumer projects can run stale MARR standards (drift D1–D6) | Run `marr sync` from a freshly-installed source project to refresh |
+| [#86](https://github.com/virtualian/marr/issues/86) | `marr sync` does not remove deprecated/replaced standards | `marr update --project --prune` removes orphans tracked by the manifest; `sync`-side handling is still pending |
 
 ## Reporting
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ marr validate
 | `marr doctor` | Interactive conflict resolution |
 | `marr standard` | Manage standards |
 | `marr sync` | Sync standards between projects |
+| `marr update --project` | Refresh canonical standards into this project (drift detection via `--check`) |
 
 Run `marr <command> --help` for detailed options.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ This file is the canonical, in-repo history. Each section is mirrored in a corre
 ## Unreleased
 
 ### Added
+- `marr update --project` — refresh canonical standards into a previously-installed project. Hash manifest at `.claude/marr/.marr-version.json` distinguishes locally-edited files (prompted) from canonical advancement (silent refresh). Flags: `--check` (drift report, non-zero exit), `--prune` (remove orphans), `--dry-run`, `--force`. `marr init --project` now writes the manifest so first-time installs are tracked. (closes [#111](https://github.com/virtualian/marr/issues/111), partially addresses [#86](https://github.com/virtualian/marr/issues/86))
 - Mandate release notes and GitHub Release for every tagged release ([#112](https://github.com/virtualian/marr/pull/112), closes [#89](https://github.com/virtualian/marr/issues/89))
 
 ### Fixed

--- a/resources/project/README.md
+++ b/resources/project/README.md
@@ -26,6 +26,10 @@ Standards in `standards/` define rules for:
 
 Edit these files to customize for your project.
 
+## Keeping Standards Current
+
+Run `marr update --project` to refresh canonical standards from the installed MARR package. Use `--check` for a non-modifying drift report. Locally-edited files are protected by a per-file prompt and timestamped backup.
+
 ## Documentation
 
 Full docs at **[virtualian.github.io/marr](https://virtualian.github.io/marr)**

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -21,6 +21,7 @@ import {
   getAllMarrProjectImportLines,
   getMarrProjectImportLine,
 } from '../utils/marr-import.js';
+import { buildManifest, writeManifest, MANIFEST_FILENAME, isStandardFilename } from '../utils/marr-manifest.js';
 
 interface InitOptions {
   user: boolean;
@@ -57,8 +58,7 @@ function discoverAvailableStandards(): StandardInfo[] {
   for (const filePath of files) {
     const filename = basename(filePath);
 
-    // Only process prj-*-standard.md files
-    if (!filename.startsWith('prj-') || !filename.endsWith('-standard.md')) {
+    if (!isStandardFilename(filename)) {
       continue;
     }
 
@@ -342,6 +342,7 @@ async function initializeProject(targetDir: string, standards: string | undefine
     logger.info(`Would create: ${marrPath}/`);
     logger.info(`Would create: ${marrProjectClaudeMdPath}`);
     logger.info(`Would create: ${marrPath}/README.md`);
+    logger.info(`Would create: ${marrPath}/${MANIFEST_FILENAME}`);
     if (selectedStandards.length > 0) {
       logger.info(`Would create: ${standardsPath}/`);
       for (const std of selectedStandards) {
@@ -370,6 +371,17 @@ async function initializeProject(targetDir: string, standards: string | undefine
     fileOps.ensureDir(standardsPath);
     copyProjectStandards(standardsPath, selectedStandards);
   }
+
+  // Write manifest so future `marr update` knows what was installed.
+  // Subscription set = the just-copied selected standards (may be empty).
+  const selectedFileNames = new Set(selectedStandards.map((s) => s.file));
+  const manifest = buildManifest(
+    standardsPath,
+    marrSetup.getMarrVersion(),
+    (name) => selectedFileNames.has(name),
+  );
+  writeManifest(marrPath, manifest);
+  logger.success(`Created: .claude/marr/${MANIFEST_FILENAME}`);
 
   // Handle project root CLAUDE.md
   addProjectClaudeMdImport(projectClaudeMdPath, targetDir);

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -27,6 +27,7 @@ import {
   cleanRegistry,
 } from '../utils/project-registry.js';
 import { regenerateTriggerTable } from '../utils/trigger-regenerator.js';
+import { generateDiff } from '../utils/diff.js';
 
 interface SyncOptions {
   from?: string;
@@ -137,51 +138,6 @@ function filesAreDifferent(path1: string, path2: string): boolean {
   } catch {
     return true;
   }
-}
-
-/**
- * Generate a simple unified diff between two strings
- */
-function generateDiff(oldContent: string, newContent: string, filename: string): string {
-  const oldLines = oldContent.split('\n');
-  const newLines = newContent.split('\n');
-
-  const lines: string[] = [];
-  lines.push(`--- a/${filename}`);
-  lines.push(`+++ b/${filename}`);
-
-  // Simple line-by-line diff (not a true unified diff algorithm, but sufficient)
-  const maxLines = Math.max(oldLines.length, newLines.length);
-  let inHunk = false;
-  let hunkStart = -1;
-
-  for (let i = 0; i < maxLines; i++) {
-    const oldLine = oldLines[i];
-    const newLine = newLines[i];
-
-    if (oldLine !== newLine) {
-      if (!inHunk) {
-        hunkStart = i;
-        inHunk = true;
-        lines.push(`@@ -${i + 1} +${i + 1} @@`);
-      }
-
-      if (oldLine !== undefined) {
-        lines.push(`-${oldLine}`);
-      }
-      if (newLine !== undefined) {
-        lines.push(`+${newLine}`);
-      }
-    } else if (inHunk) {
-      // Context line after changes
-      lines.push(` ${oldLine || ''}`);
-      if (i - hunkStart > 3) {
-        inHunk = false;
-      }
-    }
-  }
-
-  return lines.join('\n');
 }
 
 /**

--- a/src/commands/update.test.ts
+++ b/src/commands/update.test.ts
@@ -1,0 +1,267 @@
+/**
+ * End-to-end tests for the `marr update` CLI command.
+ *
+ * Spawns the built CLI as a subprocess (`node dist/index.js update ...`) and
+ * exercises a tmp-dir "fake project" with copies of canonical standards.
+ *
+ * Note: the CLI resolves canonical standards relative to its own dist
+ * location (`<repo>/resources/project/common`), so tests use the live
+ * canonical files from this repo.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  copyFileSync,
+  existsSync,
+  rmSync,
+  statSync,
+  readdirSync,
+} from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createHash } from 'node:crypto';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// dist/commands/update.test.js → repo root is two levels up from dist/.
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const CLI_BIN = join(REPO_ROOT, 'dist', 'index.js');
+const CANONICAL_DIR = join(REPO_ROOT, 'resources', 'project', 'common');
+
+const STANDARDS_REL = join('.claude', 'marr', 'standards');
+const MARR_REL = join('.claude', 'marr');
+const MANIFEST_REL = join(MARR_REL, '.marr-version.json');
+
+interface FakeProject {
+  root: string;
+  standardsDir: string;
+  marrDir: string;
+}
+
+function makeFakeProject(prefix: string): FakeProject {
+  const root = join(
+    tmpdir(),
+    `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  const marrDir = join(root, MARR_REL);
+  const standardsDir = join(root, STANDARDS_REL);
+  mkdirSync(standardsDir, { recursive: true });
+  return { root, marrDir, standardsDir };
+}
+
+function cleanup(root: string): void {
+  if (existsSync(root)) rmSync(root, { recursive: true, force: true });
+}
+
+/** Copy named canonical standards into the fake project so it looks initialised. */
+function seedCanonicalCopies(project: FakeProject, names: string[]): void {
+  for (const name of names) {
+    const src = join(CANONICAL_DIR, name);
+    if (!existsSync(src)) {
+      throw new Error(`Test setup error: canonical file missing: ${src}`);
+    }
+    copyFileSync(src, join(project.standardsDir, name));
+  }
+}
+
+/** List every canonical standard filename matching the prj-*-standard.md pattern. */
+function listAllCanonicalStandards(): string[] {
+  return readdirSync(CANONICAL_DIR).filter((n) => /^prj-.*-standard\.md$/.test(n));
+}
+
+/** Seed the fake project with copies of every canonical standard. */
+function seedAllCanonicalCopies(project: FakeProject): string[] {
+  const names = listAllCanonicalStandards();
+  seedCanonicalCopies(project, names);
+  return names;
+}
+
+function sha256OfFile(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+/** Write a manifest reflecting the current on-disk hashes of given files. */
+function writeManifestForCurrentDisk(project: FakeProject, names: string[]): void {
+  const files: Record<string, string> = {};
+  for (const name of names) {
+    files[name] = sha256OfFile(join(project.standardsDir, name));
+  }
+  const manifest = {
+    schema_version: 1,
+    marr_version: '3.5.0',
+    installed_at: '2026-01-15T12:00:00.000Z',
+    files,
+  };
+  writeFileSync(join(project.root, MANIFEST_REL), JSON.stringify(manifest, null, 2) + '\n');
+}
+
+interface RunResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function runUpdate(args: string[], cwd?: string): RunResult {
+  const result = spawnSync('node', [CLI_BIN, 'update', ...args], {
+    cwd: cwd ?? REPO_ROOT,
+    encoding: 'utf8',
+    timeout: 30_000,
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+/** Capture mtime + sha for every file under standards/, for "untouched" assertions. */
+function snapshotStandards(project: FakeProject): Record<string, { mtime: number; size: number }> {
+  const snap: Record<string, { mtime: number; size: number }> = {};
+  if (!existsSync(project.standardsDir)) return snap;
+  for (const name of readdirSync(project.standardsDir)) {
+    const s = statSync(join(project.standardsDir, name));
+    snap[name] = { mtime: s.mtimeMs, size: s.size };
+  }
+  return snap;
+}
+
+describe('marr update --check', () => {
+  let project: FakeProject;
+  beforeEach(() => { project = makeFakeProject('marr-update-check'); });
+  afterEach(() => { cleanup(project.root); });
+
+  it('exits 0 when project is in sync (manifest matches local + canonical)', () => {
+    const all = seedAllCanonicalCopies(project);
+    writeManifestForCurrentDisk(project, all);
+
+    const result = runUpdate(['--project', project.root, '--check']);
+    assert.equal(result.status, 0, `stdout: ${result.stdout}\nstderr: ${result.stderr}`);
+  });
+
+  it('exits 1 when there is local drift (file edited)', () => {
+    const all = seedAllCanonicalCopies(project);
+    writeManifestForCurrentDisk(project, all);
+
+    // Edit one local file so its hash diverges from the manifest baseline.
+    const target = join(project.standardsDir, 'prj-mcp-usage-standard.md');
+    writeFileSync(target, readFileSync(target, 'utf8') + '\n# user edit\n');
+
+    const result = runUpdate(['--project', project.root, '--check']);
+    assert.equal(result.status, 1, `stdout: ${result.stdout}\nstderr: ${result.stderr}`);
+    assert.match(result.stdout, /drifted:\s+1/);
+  });
+
+  it('exits 1 when manifest is missing (bootstrap with non-empty canonical)', () => {
+    // Empty fake project → canonical has files, local has none → all are added.
+    const result = runUpdate(['--project', project.root, '--check']);
+    assert.equal(result.status, 1, `stdout: ${result.stdout}\nstderr: ${result.stderr}`);
+  });
+
+  it('does not modify any files', () => {
+    const all = seedAllCanonicalCopies(project);
+    writeManifestForCurrentDisk(project, all);
+    const before = snapshotStandards(project);
+    const manifestBefore = readFileSync(join(project.root, MANIFEST_REL), 'utf8');
+
+    runUpdate(['--project', project.root, '--check']);
+
+    const after = snapshotStandards(project);
+    assert.deepEqual(after, before);
+    const manifestAfter = readFileSync(join(project.root, MANIFEST_REL), 'utf8');
+    assert.equal(manifestAfter, manifestBefore);
+  });
+});
+
+describe('marr update --dry-run', () => {
+  let project: FakeProject;
+  beforeEach(() => { project = makeFakeProject('marr-update-dryrun'); });
+  afterEach(() => { cleanup(project.root); });
+
+  it('exits 0 and does not modify files when changes would be applied', () => {
+    const all = seedAllCanonicalCopies(project);
+    writeManifestForCurrentDisk(project, all);
+
+    // Edit local so the run sees drift; --force makes it auto-refresh under dry-run.
+    const target = join(project.standardsDir, 'prj-mcp-usage-standard.md');
+    const originalContent = readFileSync(target, 'utf8');
+    writeFileSync(target, originalContent + '\n# user edit\n');
+
+    const before = snapshotStandards(project);
+    const manifestBefore = readFileSync(join(project.root, MANIFEST_REL), 'utf8');
+
+    const result = runUpdate(['--project', project.root, '--dry-run', '--force']);
+    assert.equal(result.status ?? 0, 0, `stdout: ${result.stdout}\nstderr: ${result.stderr}`);
+
+    const after = snapshotStandards(project);
+    assert.deepEqual(after, before, 'standards files should be unchanged after dry-run');
+    const manifestAfter = readFileSync(join(project.root, MANIFEST_REL), 'utf8');
+    assert.equal(manifestAfter, manifestBefore, 'manifest should be unchanged after dry-run');
+  });
+});
+
+describe('marr update --prune', () => {
+  let project: FakeProject;
+  beforeEach(() => { project = makeFakeProject('marr-update-prune'); });
+  afterEach(() => { cleanup(project.root); });
+
+  it('removes a manifest-tracked file that is not in canonical', () => {
+    // Seed every canonical file so the only drift is the orphan we inject.
+    const all = seedAllCanonicalCopies(project);
+    writeManifestForCurrentDisk(project, all);
+
+    // Inject an "orphan" entry into the manifest pointing to a fake file.
+    // The local copy of the orphan lives on disk so prune actually removes it.
+    const orphanName = 'prj-no-longer-canonical-standard.md';
+    const orphanPath = join(project.standardsDir, orphanName);
+    writeFileSync(orphanPath, '# orphan\n');
+
+    const orphanHash = sha256OfFile(orphanPath);
+    const manifestPath = join(project.root, MANIFEST_REL);
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    manifest.files[orphanName] = orphanHash;
+    writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+
+    assert.ok(existsSync(orphanPath), 'precondition: orphan file exists before prune');
+
+    const result = runUpdate(['--project', project.root, '--prune', '--force']);
+    assert.equal(result.status ?? 0, 0, `stdout: ${result.stdout}\nstderr: ${result.stderr}`);
+
+    assert.equal(existsSync(orphanPath), false, 'orphan file should be removed after --prune');
+
+    // Manifest should no longer reference the orphan.
+    const finalManifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    assert.equal(orphanName in finalManifest.files, false);
+  });
+});
+
+describe('marr update — flag validation', () => {
+  it('exits non-zero when --project flag is omitted (run from a non-project cwd)', () => {
+    // Run from a tmp dir that is NOT a marr project; without --project, the
+    // CLI defaults to cwd, which has no .claude/marr/, so it should error.
+    const tmp = join(tmpdir(), `marr-noflag-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tmp, { recursive: true });
+    try {
+      const result = spawnSync('node', [CLI_BIN, 'update'], {
+        cwd: tmp,
+        encoding: 'utf8',
+        timeout: 30_000,
+      });
+      assert.notEqual(result.status, 0, `stdout: ${result.stdout}\nstderr: ${result.stderr}`);
+      const combined = (result.stdout ?? '') + (result.stderr ?? '');
+      assert.match(
+        combined,
+        /--project|MARR project/i,
+        'error message should mention --project or MARR project',
+      );
+    } finally {
+      cleanup(tmp);
+    }
+  });
+});

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,0 +1,389 @@
+/**
+ * Update command — refresh canonical MARR standards into a consumer project.
+ *
+ * Usage:
+ *   marr update --project [path]    Refresh standards from canonical
+ *   marr update --project --check   Drift report only (non-zero exit if drift)
+ *   marr update --project --prune   Also remove orphaned standards
+ *   marr update --project --dry-run Preview changes without writing
+ *   marr update --project --force   Skip per-file confirms
+ *
+ * The 5-bucket model (see `compareManifest`):
+ *   - unchanged: skip
+ *   - modified:  refresh silently (canonical advanced; user untouched)
+ *   - drifted:   prompt (user edited)
+ *   - added:     prompt to install (canonical has it; subscription doesn't)
+ *   - orphan:    prune candidate (subscribed, but canonical removed it)
+ */
+
+import { Command } from 'commander';
+import { join, resolve } from 'path';
+import { unlinkSync } from 'fs';
+import * as readline from 'readline';
+import * as logger from '../utils/logger.js';
+import * as fileOps from '../utils/file-ops.js';
+import * as marrSetup from '../utils/marr-setup.js';
+import { createBackup } from '../utils/backup.js';
+import { generateDiff } from '../utils/diff.js';
+import { regenerateTriggerTable } from '../utils/trigger-regenerator.js';
+import {
+  buildManifest,
+  compareManifest,
+  isStandardFilename,
+  readManifest,
+  writeManifest,
+  MANIFEST_FILENAME,
+  type Manifest,
+  type ManifestDiff,
+} from '../utils/marr-manifest.js';
+
+const STANDARDS_SUBPATH = join('.claude', 'marr', 'standards');
+const MARR_SUBPATH = join('.claude', 'marr');
+
+interface UpdateOptions {
+  project?: string | boolean;
+  check?: boolean;
+  prune?: boolean;
+  dryRun?: boolean;
+  force?: boolean;
+}
+
+interface UpdatePlan {
+  refreshSilent: string[]; // modified bucket
+  refreshConfirmed: string[]; // drifted bucket — user said yes
+  installConfirmed: string[]; // added bucket — user said yes
+  pruneConfirmed: string[]; // orphan bucket — user said yes (and --prune)
+  skipped: string[];
+}
+
+function createReadlineInterface(): readline.Interface {
+  return readline.createInterface({ input: process.stdin, output: process.stdout });
+}
+
+function ask(rl: readline.Interface, question: string): Promise<string> {
+  return new Promise((resolve_) => {
+    rl.question(question, (answer) => resolve_(answer.trim()));
+  });
+}
+
+function resolveProjectPath(option: string | boolean | undefined): string {
+  if (typeof option === 'string') return resolve(option);
+  return process.cwd();
+}
+
+function isProjectInitialised(projectPath: string): boolean {
+  return fileOps.exists(join(projectPath, MARR_SUBPATH));
+}
+
+function printDriftReport(diff: ManifestDiff, isBootstrap: boolean): void {
+  logger.section(isBootstrap ? 'Drift Report (Bootstrap — no manifest)' : 'Drift Report');
+  logger.blank();
+  const total = diff.unchanged.length + diff.modified.length + diff.drifted.length + diff.added.length + diff.orphan.length;
+  logger.log(`  unchanged: ${diff.unchanged.length}`);
+  logger.log(`  modified:  ${diff.modified.length}    (canonical advanced; safe to refresh)`);
+  logger.log(`  drifted:   ${diff.drifted.length}    (locally edited)`);
+  logger.log(`  added:     ${diff.added.length}    (available in canonical, not subscribed)`);
+  logger.log(`  orphan:    ${diff.orphan.length}    (subscribed, no longer in canonical)`);
+  logger.blank();
+
+  for (const f of diff.modified) logger.log(`    [modified] ${f}`);
+  for (const f of diff.drifted) logger.log(`    [drifted]  ${f}`);
+  for (const f of diff.added) logger.log(`    [added]    ${f}`);
+  for (const f of diff.orphan) logger.log(`    [orphan]   ${f}`);
+
+  if (total === 0) {
+    logger.info('No standards detected.');
+  }
+  logger.blank();
+}
+
+function hasDrift(diff: ManifestDiff): boolean {
+  return (
+    diff.modified.length > 0 ||
+    diff.drifted.length > 0 ||
+    diff.added.length > 0 ||
+    diff.orphan.length > 0
+  );
+}
+
+async function planActions(
+  diff: ManifestDiff,
+  canonicalDir: string,
+  localDir: string,
+  options: UpdateOptions,
+  rl: readline.Interface,
+): Promise<UpdatePlan> {
+  const plan: UpdatePlan = {
+    refreshSilent: [...diff.modified],
+    refreshConfirmed: [],
+    installConfirmed: [],
+    pruneConfirmed: [],
+    skipped: [],
+  };
+
+  // Drifted: prompt refresh/skip/show-diff (force => refresh-all)
+  for (const file of diff.drifted) {
+    if (options.force) {
+      plan.refreshConfirmed.push(file);
+      continue;
+    }
+    const decision = await promptDriftedFile(rl, file, canonicalDir, localDir);
+    if (decision === 'refresh') plan.refreshConfirmed.push(file);
+    else plan.skipped.push(file);
+  }
+
+  // Added: prompt install (default Y; force => install-all)
+  for (const file of diff.added) {
+    if (options.force) {
+      plan.installConfirmed.push(file);
+      continue;
+    }
+    const answer = await ask(rl, `Install new standard "${file}"? [Y/n] `);
+    if (answer === '' || answer.toLowerCase().startsWith('y')) {
+      plan.installConfirmed.push(file);
+    } else {
+      plan.skipped.push(file);
+    }
+  }
+
+  // Orphan: only with --prune. Per-file confirm unless --force.
+  if (options.prune) {
+    for (const file of diff.orphan) {
+      if (options.force) {
+        plan.pruneConfirmed.push(file);
+        continue;
+      }
+      const answer = await ask(rl, `Prune orphaned standard "${file}"? [y/N] `);
+      if (answer.toLowerCase().startsWith('y')) {
+        plan.pruneConfirmed.push(file);
+      } else {
+        plan.skipped.push(file);
+      }
+    }
+  }
+
+  return plan;
+}
+
+async function promptDriftedFile(
+  rl: readline.Interface,
+  file: string,
+  canonicalDir: string,
+  localDir: string,
+): Promise<'refresh' | 'skip'> {
+  while (true) {
+    const answer = await ask(rl, `Locally-edited "${file}" — [r]efresh / [s]kip / [d]iff? `);
+    const a = answer.toLowerCase();
+    if (a.startsWith('r')) return 'refresh';
+    if (a === '' || a.startsWith('s')) return 'skip';
+    if (a.startsWith('d')) {
+      const oldContent = fileOps.readFile(join(localDir, file));
+      const newContent = fileOps.readFile(join(canonicalDir, file));
+      logger.blank();
+      logger.log(generateDiff(oldContent, newContent, file));
+      logger.blank();
+      continue;
+    }
+  }
+}
+
+function applyPlan(
+  plan: UpdatePlan,
+  canonicalDir: string,
+  localDir: string,
+  dryRun: boolean,
+): { applied: number; backups: number } {
+  let applied = 0;
+  let backups = 0;
+
+  fileOps.ensureDir(localDir);
+
+  const refresh = (file: string, label: string): void => {
+    const target = join(localDir, file);
+    if (dryRun) {
+      logger.info(`  [dry-run] ${label}: ${file}`);
+      applied++;
+      return;
+    }
+    if (fileOps.exists(target)) {
+      const backup = createBackup(target);
+      if (backup) backups++;
+    }
+    fileOps.copyFile(join(canonicalDir, file), target);
+    logger.success(`  ${label}: ${file}`);
+    applied++;
+  };
+
+  for (const f of plan.refreshSilent) refresh(f, 'refreshed');
+  for (const f of plan.refreshConfirmed) refresh(f, 'refreshed');
+  for (const f of plan.installConfirmed) refresh(f, 'installed');
+
+  for (const f of plan.pruneConfirmed) {
+    const target = join(localDir, f);
+    if (dryRun) {
+      logger.info(`  [dry-run] pruned: ${f}`);
+      applied++;
+      continue;
+    }
+    if (fileOps.exists(target)) {
+      const backup = createBackup(target);
+      if (backup) backups++;
+      unlinkSync(target);
+    }
+    logger.success(`  pruned: ${f}`);
+    applied++;
+  }
+
+  return { applied, backups };
+}
+
+function buildPostUpdateManifest(
+  priorManifest: Manifest | null,
+  plan: UpdatePlan,
+  localStandardsDir: string,
+  marrVersion: string,
+): Manifest {
+  // Subscribed = prior subscription (or bootstrap-detected local files)
+  //              + newly installed - pruned.
+  const subscribed = new Set<string>();
+
+  if (priorManifest) {
+    for (const name of Object.keys(priorManifest.files)) subscribed.add(name);
+  } else if (fileOps.exists(localStandardsDir)) {
+    for (const path of fileOps.listFiles(localStandardsDir, false)) {
+      const name = path.split('/').pop() ?? '';
+      if (isStandardFilename(name)) subscribed.add(name);
+    }
+  }
+  for (const name of plan.installConfirmed) subscribed.add(name);
+  for (const name of plan.pruneConfirmed) subscribed.delete(name);
+
+  return buildManifest(localStandardsDir, marrVersion, (name) => subscribed.has(name));
+}
+
+async function executeUpdate(options: UpdateOptions): Promise<void> {
+  // Exit codes: 0 = no drift / clean run; 1 = drift detected (--check); 2 = usage / error.
+  if (options.project === undefined || options.project === false) {
+    logger.error('--project flag is required (with optional path).');
+    logger.info('Example: marr update --project');
+    process.exit(2);
+  }
+
+  const projectPath = resolveProjectPath(options.project);
+
+  if (!isProjectInitialised(projectPath)) {
+    logger.error(`Not a MARR project: ${projectPath}`);
+    logger.info('Run: marr init --project');
+    process.exit(2);
+  }
+
+  const localMarrDir = join(projectPath, MARR_SUBPATH);
+  const localStandardsDir = join(projectPath, STANDARDS_SUBPATH);
+  const canonicalStandardsDir = join(marrSetup.getResourcesDir(), 'project', 'common');
+
+  if (!fileOps.exists(canonicalStandardsDir)) {
+    logger.error(`Canonical standards not found at: ${canonicalStandardsDir}`);
+    process.exit(2);
+  }
+
+  const priorManifest = readManifest(localMarrDir);
+  const isBootstrap = priorManifest === null;
+  const diff = compareManifest(priorManifest, localStandardsDir, canonicalStandardsDir);
+
+  // --check: report and exit; never write.
+  if (options.check) {
+    printDriftReport(diff, isBootstrap);
+    process.exit(hasDrift(diff) ? 1 : 0);
+  }
+
+  printDriftReport(diff, isBootstrap);
+
+  if (!hasDrift(diff)) {
+    if (!priorManifest) {
+      // Bootstrap with everything already aligned: just create the manifest.
+      if (!options.dryRun) {
+        const manifest = buildManifest(localStandardsDir, marrSetup.getMarrVersion());
+        writeManifest(localMarrDir, manifest);
+        logger.success(`Wrote manifest: ${MANIFEST_FILENAME}`);
+      } else {
+        logger.info(`[dry-run] Would write manifest: ${MANIFEST_FILENAME}`);
+      }
+    } else {
+      logger.info('Already up to date.');
+    }
+    return;
+  }
+
+  const rl = createReadlineInterface();
+  let plan: UpdatePlan;
+  try {
+    plan = await planActions(diff, canonicalStandardsDir, localStandardsDir, options, rl);
+  } finally {
+    rl.close();
+  }
+
+  logger.blank();
+  logger.section(options.dryRun ? 'Dry Run — Would Apply' : 'Applying Updates');
+  logger.blank();
+
+  const { applied, backups } = applyPlan(plan, canonicalStandardsDir, localStandardsDir, options.dryRun ?? false);
+
+  if (!options.dryRun && applied > 0) {
+    const manifest = buildPostUpdateManifest(priorManifest, plan, localStandardsDir, marrSetup.getMarrVersion());
+    writeManifest(localMarrDir, manifest);
+    logger.success(`Wrote manifest: ${MANIFEST_FILENAME}`);
+
+    const tt = regenerateTriggerTable(projectPath);
+    if (tt.success) {
+      logger.success(`Regenerated trigger table (${tt.standardsCount} standards)`);
+    } else if (tt.error) {
+      logger.warning(`Could not regenerate trigger table: ${tt.error}`);
+    }
+  }
+
+  logger.blank();
+  if (options.dryRun) {
+    logger.info(`Dry run complete: ${applied} change(s) would be applied.`);
+  } else {
+    logger.success(`Update complete: ${applied} change(s), ${backups} backup(s) created.`);
+  }
+}
+
+export function updateCommand(program: Command): void {
+  program
+    .command('update')
+    .description('Refresh canonical MARR standards into a consumer project')
+    .option('-p, --project [path]', 'Update project at [path] (defaults to current directory)')
+    .option('--check', 'Drift report only; non-zero exit if drift detected; no writes')
+    .option('--prune', 'Also remove orphaned standards (subscribed, no longer in canonical)')
+    .option('-n, --dry-run', 'Preview changes without writing')
+    .option('-f, --force', 'Skip per-file confirms (refresh drifted, install added, prune orphans)')
+    .addHelpText(
+      'after',
+      `
+Drift buckets:
+  modified  Canonical advanced; you have not edited locally — refreshed silently.
+  drifted   You have edited locally — prompted (refresh/skip/show-diff).
+  added     Available in canonical, not subscribed — prompted (default install).
+  orphan    Subscribed, but canonical removed it — pruned only with --prune.
+
+Examples:
+  $ marr update --project              Refresh current project
+  $ marr update --project --check      Report drift; exit non-zero if behind canonical
+  $ marr update --project --prune      Also remove orphaned standards
+  $ marr update --project --dry-run    Preview without writing
+  $ marr update --project --force      Skip prompts (CI-friendly)
+
+First run on a project with no manifest enters bootstrap mode: existing
+local files become the subscription set; new canonical standards are
+offered for installation.`,
+    )
+    .action(async (options: UpdateOptions) => {
+      try {
+        await executeUpdate(options);
+      } catch (err) {
+        logger.error((err as Error).message);
+        process.exit(2);
+      }
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { cleanCommand } from './commands/clean.js';
 import { standardCommand } from './commands/standard.js';
 import { doctorCommand } from './commands/doctor.js';
 import { syncCommand } from './commands/sync.js';
+import { updateCommand } from './commands/update.js';
 
 // Get package.json for version
 const __filename = fileURLToPath(import.meta.url);
@@ -45,6 +46,7 @@ Examples:
   $ marr standard validate --all  Validate all standard frontmatter
   $ marr standard list            List standards with triggers
   $ marr sync                     Sync standards between projects
+  $ marr update --project         Refresh canonical standards into this project
 
 Run 'marr <command> --help' for detailed help on each command.`);
 
@@ -55,6 +57,7 @@ cleanCommand(program);
 standardCommand(program);
 doctorCommand(program);
 syncCommand(program);
+updateCommand(program);
 
 // Parse arguments
 program.parse(process.argv);

--- a/src/schema/manifest.test.ts
+++ b/src/schema/manifest.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for MARR project manifest zod schema.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { ManifestSchema } from './manifest.js';
+
+const VALID_HASH = 'a'.repeat(64);
+
+function validManifest(): unknown {
+  return {
+    schema_version: 1,
+    marr_version: '3.5.0',
+    installed_at: '2026-01-15T12:00:00.000Z',
+    files: {
+      'prj-testing-standard.md': VALID_HASH,
+    },
+  };
+}
+
+describe('ManifestSchema', () => {
+  it('accepts a valid manifest', () => {
+    const result = ManifestSchema.safeParse(validManifest());
+    assert.equal(result.success, true);
+  });
+
+  it('accepts a manifest with empty files map', () => {
+    const m = validManifest() as Record<string, unknown>;
+    m.files = {};
+    const result = ManifestSchema.safeParse(m);
+    assert.equal(result.success, true);
+  });
+
+  it('accepts an ISO timestamp with timezone offset', () => {
+    const m = validManifest() as Record<string, unknown>;
+    m.installed_at = '2026-01-15T12:00:00+01:00';
+    const result = ManifestSchema.safeParse(m);
+    assert.equal(result.success, true);
+  });
+
+  it('rejects schema_version other than literal 1', () => {
+    const m = validManifest() as Record<string, unknown>;
+    m.schema_version = 2;
+    const result = ManifestSchema.safeParse(m);
+    assert.equal(result.success, false);
+  });
+
+  it('rejects schema_version as a string', () => {
+    const m = validManifest() as Record<string, unknown>;
+    m.schema_version = '1';
+    const result = ManifestSchema.safeParse(m);
+    assert.equal(result.success, false);
+  });
+
+  it('rejects non-semver marr_version', () => {
+    const m = validManifest() as Record<string, unknown>;
+    m.marr_version = '3.5';
+    const result = ManifestSchema.safeParse(m);
+    assert.equal(result.success, false);
+  });
+
+  it('rejects marr_version with leading v', () => {
+    const m = validManifest() as Record<string, unknown>;
+    m.marr_version = 'v3.5.0';
+    const result = ManifestSchema.safeParse(m);
+    assert.equal(result.success, false);
+  });
+
+  it('accepts semver with prerelease suffix', () => {
+    const m = validManifest() as Record<string, unknown>;
+    m.marr_version = '3.5.0-rc.1';
+    const result = ManifestSchema.safeParse(m);
+    assert.equal(result.success, true);
+  });
+
+  it('rejects non-ISO installed_at', () => {
+    const m = validManifest() as Record<string, unknown>;
+    m.installed_at = '2026-01-15 12:00:00';
+    const result = ManifestSchema.safeParse(m);
+    assert.equal(result.success, false);
+  });
+
+  it('rejects installed_at as plain date', () => {
+    const m = validManifest() as Record<string, unknown>;
+    m.installed_at = '2026-01-15';
+    const result = ManifestSchema.safeParse(m);
+    assert.equal(result.success, false);
+  });
+
+  it('rejects hash that is too short', () => {
+    const m = validManifest() as Record<string, unknown>;
+    m.files = { 'prj-foo-standard.md': 'a'.repeat(63) };
+    const result = ManifestSchema.safeParse(m);
+    assert.equal(result.success, false);
+  });
+
+  it('rejects hash that is too long', () => {
+    const m = validManifest() as Record<string, unknown>;
+    m.files = { 'prj-foo-standard.md': 'a'.repeat(65) };
+    const result = ManifestSchema.safeParse(m);
+    assert.equal(result.success, false);
+  });
+
+  it('rejects uppercase hex in hash', () => {
+    const m = validManifest() as Record<string, unknown>;
+    m.files = { 'prj-foo-standard.md': 'A'.repeat(64) };
+    const result = ManifestSchema.safeParse(m);
+    assert.equal(result.success, false);
+  });
+
+  it('rejects invalid characters in hash', () => {
+    const m = validManifest() as Record<string, unknown>;
+    m.files = { 'prj-foo-standard.md': 'g'.repeat(64) };
+    const result = ManifestSchema.safeParse(m);
+    assert.equal(result.success, false);
+  });
+
+  it('rejects empty filename in files map', () => {
+    const m = validManifest() as Record<string, unknown>;
+    m.files = { '': VALID_HASH };
+    const result = ManifestSchema.safeParse(m);
+    assert.equal(result.success, false);
+  });
+});

--- a/src/schema/manifest.ts
+++ b/src/schema/manifest.ts
@@ -1,0 +1,25 @@
+/**
+ * Zod schema for MARR project manifest (`.claude/marr/.marr-version.json`).
+ *
+ * The manifest records the SHA-256 hash of every standard MARR has installed
+ * into a project. It is the source of truth for `marr update`'s drift
+ * detection and for distinguishing user-edited files from canonical
+ * advancement.
+ */
+
+import { z } from 'zod';
+
+const SHA256_HEX = z.string().regex(/^[0-9a-f]{64}$/, 'must be 64-char lowercase hex');
+const SEMVER = z.string().regex(/^\d+\.\d+\.\d+(?:[-+].+)?$/, 'must be a semver string');
+const ISO_TIMESTAMP = z.string().datetime({ offset: true }).or(z.string().datetime());
+
+export const ManifestSchema = z.object({
+  schema_version: z.literal(1),
+  marr_version: SEMVER,
+  installed_at: ISO_TIMESTAMP,
+  files: z.record(z.string().min(1), SHA256_HEX),
+});
+
+export type Manifest = z.infer<typeof ManifestSchema>;
+
+export const MANIFEST_FILENAME = '.marr-version.json';

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -1,0 +1,47 @@
+/**
+ * Simple unified-style diff between two strings.
+ *
+ * Not a true unified-diff algorithm — sufficient for showing line-level
+ * changes to the user when prompting about file refreshes. Shared by
+ * `marr sync` and `marr update`.
+ */
+
+export function generateDiff(oldContent: string, newContent: string, filename: string): string {
+  const oldLines = oldContent.split('\n');
+  const newLines = newContent.split('\n');
+
+  const lines: string[] = [];
+  lines.push(`--- a/${filename}`);
+  lines.push(`+++ b/${filename}`);
+
+  const maxLines = Math.max(oldLines.length, newLines.length);
+  let inHunk = false;
+  let hunkStart = -1;
+
+  for (let i = 0; i < maxLines; i++) {
+    const oldLine = oldLines[i];
+    const newLine = newLines[i];
+
+    if (oldLine !== newLine) {
+      if (!inHunk) {
+        hunkStart = i;
+        inHunk = true;
+        lines.push(`@@ -${i + 1} +${i + 1} @@`);
+      }
+
+      if (oldLine !== undefined) {
+        lines.push(`-${oldLine}`);
+      }
+      if (newLine !== undefined) {
+        lines.push(`+${newLine}`);
+      }
+    } else if (inHunk) {
+      lines.push(` ${oldLine || ''}`);
+      if (i - hunkStart > 3) {
+        inHunk = false;
+      }
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/src/utils/marr-manifest.test.ts
+++ b/src/utils/marr-manifest.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Tests for marr-manifest utility (hash, read/write, build, compare).
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, writeFileSync, rmSync, existsSync, readdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  hashFile,
+  readManifest,
+  writeManifest,
+  buildManifest,
+  compareManifest,
+  manifestPath,
+  type Manifest,
+} from './marr-manifest.js';
+
+function makeTmpDir(prefix: string): string {
+  const dir = join(
+    tmpdir(),
+    `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function cleanup(dir: string): void {
+  if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+}
+
+const VALID_HASH = 'a'.repeat(64);
+
+function sampleManifest(overrides: Partial<Manifest> = {}): Manifest {
+  return {
+    schema_version: 1,
+    marr_version: '3.5.0',
+    installed_at: '2026-01-15T12:00:00.000Z',
+    files: {
+      'prj-testing-standard.md': VALID_HASH,
+    },
+    ...overrides,
+  };
+}
+
+describe('hashFile', () => {
+  let tmp: string;
+  beforeEach(() => { tmp = makeTmpDir('marr-hashfile'); });
+  afterEach(() => { cleanup(tmp); });
+
+  it('produces deterministic SHA-256 hex of a known string', () => {
+    const f = join(tmp, 'a.txt');
+    writeFileSync(f, 'hello');
+    assert.equal(
+      hashFile(f),
+      '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
+    );
+  });
+
+  it('returns the same hash for identical content across files', () => {
+    const a = join(tmp, 'a.txt');
+    const b = join(tmp, 'b.txt');
+    writeFileSync(a, 'identical content');
+    writeFileSync(b, 'identical content');
+    assert.equal(hashFile(a), hashFile(b));
+  });
+
+  it('returns different hashes for different content', () => {
+    const a = join(tmp, 'a.txt');
+    const b = join(tmp, 'b.txt');
+    writeFileSync(a, 'content A');
+    writeFileSync(b, 'content B');
+    assert.notEqual(hashFile(a), hashFile(b));
+  });
+});
+
+describe('writeManifest + readManifest', () => {
+  let tmp: string;
+  beforeEach(() => { tmp = makeTmpDir('marr-rwmanifest'); });
+  afterEach(() => { cleanup(tmp); });
+
+  it('round-trips a manifest with deep equality', () => {
+    const m = sampleManifest();
+    writeManifest(tmp, m);
+    const read = readManifest(tmp);
+    assert.deepEqual(read, m);
+  });
+
+  it('write is atomic — no .tmp file remains afterwards', () => {
+    writeManifest(tmp, sampleManifest());
+    const remaining = readdirSync(tmp).filter((n) => n.endsWith('.tmp'));
+    assert.deepEqual(remaining, []);
+  });
+
+  it('returns null when manifest file is missing', () => {
+    assert.equal(readManifest(tmp), null);
+  });
+
+  it('returns null when manifest file is invalid JSON', () => {
+    writeFileSync(manifestPath(tmp), '{ this is not json');
+    assert.equal(readManifest(tmp), null);
+  });
+
+  it('returns null when JSON parses but fails schema validation', () => {
+    writeFileSync(
+      manifestPath(tmp),
+      JSON.stringify({ schema_version: 99, marr_version: '3.5.0', installed_at: '2026-01-15T12:00:00.000Z', files: {} }),
+    );
+    assert.equal(readManifest(tmp), null);
+  });
+
+  it('returns null when JSON has wrong hash format', () => {
+    writeFileSync(
+      manifestPath(tmp),
+      JSON.stringify({
+        schema_version: 1,
+        marr_version: '3.5.0',
+        installed_at: '2026-01-15T12:00:00.000Z',
+        files: { 'prj-foo-standard.md': 'too-short' },
+      }),
+    );
+    assert.equal(readManifest(tmp), null);
+  });
+});
+
+describe('buildManifest', () => {
+  let tmp: string;
+  let standardsDir: string;
+  beforeEach(() => {
+    tmp = makeTmpDir('marr-build');
+    standardsDir = join(tmp, 'standards');
+    mkdirSync(standardsDir, { recursive: true });
+  });
+  afterEach(() => { cleanup(tmp); });
+
+  it('only includes prj-*-standard.md files; ignores README and other files', () => {
+    writeFileSync(join(standardsDir, 'prj-testing-standard.md'), 'content A');
+    writeFileSync(join(standardsDir, 'prj-version-control-standard.md'), 'content B');
+    writeFileSync(join(standardsDir, 'README.md'), '# readme');
+    writeFileSync(join(standardsDir, 'notes.txt'), 'random');
+    writeFileSync(join(standardsDir, 'something-else.md'), 'no prefix');
+
+    const manifest = buildManifest(standardsDir, '3.5.0');
+
+    assert.deepEqual(
+      Object.keys(manifest.files).sort(),
+      ['prj-testing-standard.md', 'prj-version-control-standard.md'],
+    );
+    assert.equal(manifest.schema_version, 1);
+    assert.equal(manifest.marr_version, '3.5.0');
+    assert.match(manifest.installed_at, /^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('hashes match hashFile output for each included file', () => {
+    const path = join(standardsDir, 'prj-testing-standard.md');
+    writeFileSync(path, 'standard content');
+    const manifest = buildManifest(standardsDir, '3.5.0');
+    assert.equal(manifest.files['prj-testing-standard.md'], hashFile(path));
+  });
+
+  it('respects fileFilter — only files passing the filter appear', () => {
+    writeFileSync(join(standardsDir, 'prj-testing-standard.md'), 'a');
+    writeFileSync(join(standardsDir, 'prj-version-control-standard.md'), 'b');
+    writeFileSync(join(standardsDir, 'prj-documentation-standard.md'), 'c');
+
+    const manifest = buildManifest(
+      standardsDir,
+      '3.5.0',
+      (name) => name === 'prj-testing-standard.md',
+    );
+
+    assert.deepEqual(Object.keys(manifest.files), ['prj-testing-standard.md']);
+  });
+
+  it('returns empty files map when standards dir does not exist', () => {
+    const m = buildManifest(join(tmp, 'does-not-exist'), '3.5.0');
+    assert.deepEqual(m.files, {});
+  });
+});
+
+describe('compareManifest — bootstrap (manifest=null)', () => {
+  let tmp: string;
+  let canonicalDir: string;
+  let localDir: string;
+  beforeEach(() => {
+    tmp = makeTmpDir('marr-bootstrap');
+    canonicalDir = join(tmp, 'canonical');
+    localDir = join(tmp, 'local');
+    mkdirSync(canonicalDir, { recursive: true });
+    mkdirSync(localDir, { recursive: true });
+  });
+  afterEach(() => { cleanup(tmp); });
+
+  it('classifies canonical-only files as added', () => {
+    writeFileSync(join(canonicalDir, 'prj-testing-standard.md'), 'A');
+
+    const diff = compareManifest(null, localDir, canonicalDir);
+    assert.deepEqual(diff.added, ['prj-testing-standard.md']);
+    assert.deepEqual(diff.unchanged, []);
+    assert.deepEqual(diff.drifted, []);
+    assert.deepEqual(diff.modified, []);
+    assert.deepEqual(diff.orphan, []);
+  });
+
+  it('classifies matching local+canonical as unchanged', () => {
+    writeFileSync(join(canonicalDir, 'prj-testing-standard.md'), 'same');
+    writeFileSync(join(localDir, 'prj-testing-standard.md'), 'same');
+
+    const diff = compareManifest(null, localDir, canonicalDir);
+    assert.deepEqual(diff.unchanged, ['prj-testing-standard.md']);
+    assert.deepEqual(diff.drifted, []);
+  });
+
+  it('classifies differing local+canonical as drifted', () => {
+    writeFileSync(join(canonicalDir, 'prj-testing-standard.md'), 'canonical');
+    writeFileSync(join(localDir, 'prj-testing-standard.md'), 'edited');
+
+    const diff = compareManifest(null, localDir, canonicalDir);
+    assert.deepEqual(diff.drifted, ['prj-testing-standard.md']);
+    assert.deepEqual(diff.unchanged, []);
+  });
+
+  it('does not produce orphan or modified buckets in bootstrap mode', () => {
+    writeFileSync(join(canonicalDir, 'prj-a-standard.md'), 'a');
+    writeFileSync(join(canonicalDir, 'prj-b-standard.md'), 'b');
+    writeFileSync(join(localDir, 'prj-a-standard.md'), 'a');
+    writeFileSync(join(localDir, 'prj-c-standard.md'), 'extra'); // local-only file
+
+    const diff = compareManifest(null, localDir, canonicalDir);
+    assert.deepEqual(diff.modified, []);
+    assert.deepEqual(diff.orphan, []);
+  });
+});
+
+describe('compareManifest — with manifest', () => {
+  let tmp: string;
+  let canonicalDir: string;
+  let localDir: string;
+  beforeEach(() => {
+    tmp = makeTmpDir('marr-withmanifest');
+    canonicalDir = join(tmp, 'canonical');
+    localDir = join(tmp, 'local');
+    mkdirSync(canonicalDir, { recursive: true });
+    mkdirSync(localDir, { recursive: true });
+  });
+  afterEach(() => { cleanup(tmp); });
+
+  it('subscribed file with matching local & canonical hashes is unchanged', () => {
+    writeFileSync(join(canonicalDir, 'prj-x-standard.md'), 'same');
+    writeFileSync(join(localDir, 'prj-x-standard.md'), 'same');
+    const baselineHash = hashFile(join(localDir, 'prj-x-standard.md'));
+
+    const manifest = sampleManifest({ files: { 'prj-x-standard.md': baselineHash } });
+    const diff = compareManifest(manifest, localDir, canonicalDir);
+    assert.deepEqual(diff.unchanged, ['prj-x-standard.md']);
+    assert.deepEqual(diff.modified, []);
+    assert.deepEqual(diff.drifted, []);
+  });
+
+  it('subscribed file matching baseline but canonical advanced is modified (silent refresh)', () => {
+    writeFileSync(join(localDir, 'prj-x-standard.md'), 'baseline');
+    writeFileSync(join(canonicalDir, 'prj-x-standard.md'), 'baseline-v2');
+    const baselineHash = hashFile(join(localDir, 'prj-x-standard.md'));
+
+    const manifest = sampleManifest({ files: { 'prj-x-standard.md': baselineHash } });
+    const diff = compareManifest(manifest, localDir, canonicalDir);
+    assert.deepEqual(diff.modified, ['prj-x-standard.md']);
+    assert.deepEqual(diff.unchanged, []);
+    assert.deepEqual(diff.drifted, []);
+  });
+
+  it('subscribed file with local hash != baseline is drifted (user edited)', () => {
+    writeFileSync(join(canonicalDir, 'prj-x-standard.md'), 'baseline');
+    writeFileSync(join(localDir, 'prj-x-standard.md'), 'user-edit');
+    const baselineHash = hashFile(join(canonicalDir, 'prj-x-standard.md'));
+
+    const manifest = sampleManifest({ files: { 'prj-x-standard.md': baselineHash } });
+    const diff = compareManifest(manifest, localDir, canonicalDir);
+    assert.deepEqual(diff.drifted, ['prj-x-standard.md']);
+    assert.deepEqual(diff.unchanged, []);
+  });
+
+  it('subscribed file deleted locally is drifted', () => {
+    writeFileSync(join(canonicalDir, 'prj-x-standard.md'), 'baseline');
+    // Deliberately do not write the local copy.
+
+    const manifest = sampleManifest({ files: { 'prj-x-standard.md': VALID_HASH } });
+    const diff = compareManifest(manifest, localDir, canonicalDir);
+    assert.deepEqual(diff.drifted, ['prj-x-standard.md']);
+  });
+
+  it('canonical file not in manifest subscription is added', () => {
+    writeFileSync(join(canonicalDir, 'prj-new-standard.md'), 'new');
+
+    const manifest = sampleManifest({ files: {} });
+    const diff = compareManifest(manifest, localDir, canonicalDir);
+    assert.deepEqual(diff.added, ['prj-new-standard.md']);
+  });
+
+  it('manifest file not in canonical is orphan', () => {
+    // No canonical, no local — only manifest references it.
+    const manifest = sampleManifest({ files: { 'prj-removed-standard.md': VALID_HASH } });
+    const diff = compareManifest(manifest, localDir, canonicalDir);
+    assert.deepEqual(diff.orphan, ['prj-removed-standard.md']);
+  });
+
+  it('handles a mixed scenario across all five buckets', () => {
+    // unchanged
+    writeFileSync(join(canonicalDir, 'prj-u-standard.md'), 'u');
+    writeFileSync(join(localDir, 'prj-u-standard.md'), 'u');
+    const uHash = hashFile(join(localDir, 'prj-u-standard.md'));
+
+    // modified
+    writeFileSync(join(canonicalDir, 'prj-m-standard.md'), 'm-new');
+    writeFileSync(join(localDir, 'prj-m-standard.md'), 'm-old');
+    const mHash = hashFile(join(localDir, 'prj-m-standard.md'));
+
+    // drifted
+    writeFileSync(join(canonicalDir, 'prj-d-standard.md'), 'd-canonical');
+    writeFileSync(join(localDir, 'prj-d-standard.md'), 'd-edited');
+    const dHash = hashFile(join(canonicalDir, 'prj-d-standard.md'));
+
+    // added (in canonical, not in subscription)
+    writeFileSync(join(canonicalDir, 'prj-a-standard.md'), 'a');
+
+    // orphan (in subscription, not in canonical)
+    const orphanHash = VALID_HASH;
+
+    const manifest = sampleManifest({
+      files: {
+        'prj-u-standard.md': uHash,
+        'prj-m-standard.md': mHash,
+        'prj-d-standard.md': dHash,
+        'prj-o-standard.md': orphanHash,
+      },
+    });
+
+    const diff = compareManifest(manifest, localDir, canonicalDir);
+    assert.deepEqual(diff.unchanged, ['prj-u-standard.md']);
+    assert.deepEqual(diff.modified, ['prj-m-standard.md']);
+    assert.deepEqual(diff.drifted, ['prj-d-standard.md']);
+    assert.deepEqual(diff.added, ['prj-a-standard.md']);
+    assert.deepEqual(diff.orphan, ['prj-o-standard.md']);
+  });
+});

--- a/src/utils/marr-manifest.ts
+++ b/src/utils/marr-manifest.ts
@@ -1,0 +1,193 @@
+/**
+ * Manifest helpers for `marr update`.
+ *
+ * The project manifest records SHA-256 hashes of every standard MARR has
+ * installed. By comparing local hashes, manifest hashes (the recorded
+ * baseline), and canonical hashes (the bundled npm package) we classify
+ * each file into one of five buckets — see `compareManifest`.
+ */
+
+import { createHash } from 'crypto';
+import { renameSync, readFileSync } from 'fs';
+import { join, basename } from 'path';
+import * as fileOps from './file-ops.js';
+import { ManifestSchema, MANIFEST_FILENAME, type Manifest } from '../schema/manifest.js';
+
+export { MANIFEST_FILENAME, type Manifest };
+
+/** Files in `<dir>/standards/` that MARR considers standards. */
+const STANDARD_FILE_PATTERN = /^prj-.*-standard\.md$/;
+
+/** Whether a filename is a MARR project standard (`prj-*-standard.md`). */
+export function isStandardFilename(name: string): boolean {
+  return STANDARD_FILE_PATTERN.test(name);
+}
+
+/** SHA-256 hex digest of a file's raw bytes. */
+export function hashFile(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+/** Path to the manifest inside `.claude/marr/`. */
+export function manifestPath(marrDir: string): string {
+  return join(marrDir, MANIFEST_FILENAME);
+}
+
+/**
+ * Read and validate the manifest. Returns null when missing or invalid —
+ * callers fall through to bootstrap.
+ */
+export function readManifest(marrDir: string): Manifest | null {
+  const path = manifestPath(marrDir);
+  if (!fileOps.exists(path)) return null;
+
+  try {
+    const parsed: unknown = JSON.parse(fileOps.readFile(path));
+    const result = ManifestSchema.safeParse(parsed);
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write the manifest atomically: write tmp + rename, so a SIGINT mid-write
+ * never leaves a partial JSON file on disk.
+ */
+export function writeManifest(marrDir: string, manifest: Manifest): void {
+  fileOps.ensureDir(marrDir);
+  const finalPath = manifestPath(marrDir);
+  const tmpPath = `${finalPath}.tmp`;
+  const content = JSON.stringify(manifest, null, 2) + '\n';
+  fileOps.writeFile(tmpPath, content);
+  renameSync(tmpPath, finalPath);
+}
+
+/**
+ * Build a manifest from the standards currently in a directory.
+ * Used by `init` (record what was installed) and `update` (record new state).
+ */
+export function buildManifest(
+  standardsDir: string,
+  marrVersion: string,
+  fileFilter?: (filename: string) => boolean,
+): Manifest {
+  const files: Record<string, string> = {};
+  if (fileOps.exists(standardsDir)) {
+    for (const path of fileOps.listFiles(standardsDir, false)) {
+      const name = basename(path);
+      if (!isStandardFilename(name)) continue;
+      if (fileFilter && !fileFilter(name)) continue;
+      files[name] = hashFile(path);
+    }
+  }
+  return {
+    schema_version: 1,
+    marr_version: marrVersion,
+    installed_at: new Date().toISOString(),
+    files,
+  };
+}
+
+export interface ManifestDiff {
+  /** Local hash == manifest hash == canonical hash. Skip. */
+  unchanged: string[];
+  /** Local hash == manifest hash, canonical advanced. Silent refresh. */
+  modified: string[];
+  /** Local hash != manifest hash. User edited. Prompt. */
+  drifted: string[];
+  /** In canonical, missing from manifest. Available — prompt to install. */
+  added: string[];
+  /** In manifest, missing from canonical. Prune candidate. */
+  orphan: string[];
+}
+
+/**
+ * Classify every relevant file into one of the 5 buckets.
+ *
+ * - `manifest` is the recorded baseline (or null = bootstrap).
+ * - `localStandardsDir` is the consumer project's standards directory.
+ * - `canonicalStandardsDir` is the bundled `resources/project/common`.
+ *
+ * In bootstrap (manifest is null) we treat the local directory as the
+ * subscribed set: files present locally that match canonical are `unchanged`;
+ * files present locally that differ from canonical are `drifted`; files in
+ * canonical but not locally are `added`. There are no orphans yet.
+ */
+export function compareManifest(
+  manifest: Manifest | null,
+  localStandardsDir: string,
+  canonicalStandardsDir: string,
+): ManifestDiff {
+  const diff: ManifestDiff = {
+    unchanged: [],
+    modified: [],
+    drifted: [],
+    added: [],
+    orphan: [],
+  };
+
+  const canonicalFiles = listStandards(canonicalStandardsDir);
+  const localFiles = new Set(listStandards(localStandardsDir));
+
+  if (manifest === null) {
+    // Bootstrap: subscription = current local files.
+    for (const name of canonicalFiles) {
+      if (!localFiles.has(name)) {
+        diff.added.push(name);
+        continue;
+      }
+      const localHash = hashFile(join(localStandardsDir, name));
+      const canonicalHash = hashFile(join(canonicalStandardsDir, name));
+      if (localHash === canonicalHash) {
+        diff.unchanged.push(name);
+      } else {
+        diff.drifted.push(name);
+      }
+    }
+    return diff;
+  }
+
+  const subscribed = new Set(Object.keys(manifest.files));
+  const canonicalSet = new Set(canonicalFiles);
+
+  // Files in subscription: classify as unchanged / modified / drifted.
+  for (const name of subscribed) {
+    if (!canonicalSet.has(name)) {
+      diff.orphan.push(name);
+      continue;
+    }
+    const baselineHash = manifest.files[name];
+    const canonicalHash = hashFile(join(canonicalStandardsDir, name));
+    const localPath = join(localStandardsDir, name);
+    const localHash = localFiles.has(name) ? hashFile(localPath) : null;
+
+    if (localHash === null) {
+      // Subscribed file deleted locally — treat as drifted (user removed it).
+      diff.drifted.push(name);
+    } else if (localHash !== baselineHash) {
+      diff.drifted.push(name);
+    } else if (baselineHash !== canonicalHash) {
+      diff.modified.push(name);
+    } else {
+      diff.unchanged.push(name);
+    }
+  }
+
+  // Files in canonical not in subscription: available to add.
+  for (const name of canonicalFiles) {
+    if (!subscribed.has(name)) {
+      diff.added.push(name);
+    }
+  }
+
+  return diff;
+}
+
+function listStandards(dir: string): string[] {
+  if (!fileOps.exists(dir)) return [];
+  return fileOps
+    .listFiles(dir, false)
+    .map((p) => basename(p))
+    .filter(isStandardFilename);
+}

--- a/src/utils/marr-setup.ts
+++ b/src/utils/marr-setup.ts
@@ -29,6 +29,20 @@ export function getResourcesDir(): string {
 }
 
 /**
+ * Get the installed marr package version from package.json.
+ * Cached after first read.
+ */
+let _marrVersion: string | null = null;
+export function getMarrVersion(): string {
+  if (_marrVersion === null) {
+    const pkgPath = join(__dirname, '../../package.json');
+    const pkg = JSON.parse(fileOps.readFile(pkgPath)) as { version: string };
+    _marrVersion = pkg.version;
+  }
+  return _marrVersion;
+}
+
+/**
  * Check if MARR is already set up at ~/.claude/marr/
  */
 export function isMarrSetup(): boolean {


### PR DESCRIPTION
## Summary

- New command `marr update --project` re-installs canonical MARR standards from the bundled npm package into a previously-initialised consumer project, closing the gap that left 4 of 5 audited projects stale on three or more standards (issue #111, follow-up to audit #107).
- Drift detection via a SHA-256 hash manifest at `.claude/marr/.marr-version.json`. The manifest distinguishes user-edited files (prompted) from canonical advancement (silent refresh) — without it, update couldn't tell the two apart, which is the entire point of having one.
- `marr init --project` now writes the manifest so first-time installs are tracked.

## Behaviour

`marr update --project` flags:
- `--check` — drift report only; exits 1 if drift detected; never writes
- `--prune` — also remove orphaned standards (subscribed but no longer in canonical)
- `--dry-run` — preview without writing
- `--force` — skip per-file confirms (CI-friendly)

Exit codes are CI-discriminable: `0` = clean, `1` = drift detected under `--check`, `2` = usage or runtime error.

## 5-bucket diff model

| Bucket | Local hash | Manifest hash | Canonical hash | Action |
|---|---|---|---|---|
| `unchanged` | == | == | == | skip |
| `modified` | == manifest | matches | differs | silent refresh |
| `drifted` | != manifest | — | — | prompt (refresh/skip/show-diff) |
| `added` | — | absent | present | prompt to install |
| `orphan` | — | present | absent | prune candidate |

First run on a project with no manifest enters **bootstrap mode**: existing local files become the subscription set, the manifest is born from that decision, and new canonical standards are offered for installation.

## Safety

- Backups (timestamped `.bak`) before any overwrite, via existing `utils/backup`.
- Manifest writes are atomic (tmp + rename) — SIGINT mid-update cannot corrupt the file.
- `--prune` only deletes files present in the prior manifest baseline; never auto-deletes user-authored standards.
- Trigger table regenerated after any standards change (mirrors `marr sync`).

## Refactoring (low-risk, included)

- `generateDiff` extracted from `sync.ts` into `src/utils/diff.ts`; both commands now share it (sync.ts net –45 LOC).
- `getMarrVersion` added to `marr-setup.ts`, used by both `init` and `update`.
- `isStandardFilename` predicate exported from `marr-manifest.ts`; `init.ts` adopted it (kills a duplicate inline regex).

## Files

- New (7): `src/commands/update.ts`, `src/commands/update.test.ts`, `src/schema/manifest.ts`, `src/schema/manifest.test.ts`, `src/utils/marr-manifest.ts`, `src/utils/marr-manifest.test.ts`, `src/utils/diff.ts`
- Modified (8): `src/commands/init.ts`, `src/commands/sync.ts`, `src/index.ts`, `src/utils/marr-setup.ts`, `README.md`, `RELEASE_NOTES.md` (Unreleased entry), `KNOWN_ISSUES.md` (#111 row removed, #86 wording updated), `resources/project/README.md`

No `package.json` version bump in this PR — the bump happens at release time per the version-control standard. The Unreleased section in `RELEASE_NOTES.md` already has the entry.

## Test plan

- [x] `npm test` — 105/105 pass (was 59 before, +46 new across schema/util/command tests)
- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] End-to-end smoke against tmpdir fixture: bootstrap → drift detection → `--force` refresh → manifest write → post-run `--check` exits 0
- [x] Exit codes verified: usage error → 2; not-marr-project → 2; `--check` drift → 1; `--check` clean → 0
- [ ] Manual sanity-check of `marr update --project --check` against one of the actually-stale audited consumer projects (`~/projects/ask-viki`, `~/projects/learn-offline-first-apps`, `~/projects/pai`, or `~/projects/npm-scanner`) before merge — the smoke fixture is synthetic; a real-world run will confirm the bootstrap UX is reasonable.

Closes #111. Partially addresses #86 (orphan removal via `--prune`; sync-side handling still pending).